### PR TITLE
Write value of executing options to log upon database open.

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -140,6 +140,8 @@ DBImpl::DBImpl(const Options& options, const std::string& dbname)
 
   versions_ = new VersionSet(dbname_, &options_, table_cache_,
                              &internal_comparator_);
+
+  options_.Dump(options_.info_log);
 }
 
 DBImpl::~DBImpl() {

--- a/include/leveldb/options.h
+++ b/include/leveldb/options.h
@@ -137,6 +137,8 @@ struct Options {
 
   // Create an Options object with default values for all fields.
   Options();
+
+  void Dump(Logger * log) const;
 };
 
 // Options that control read operations

--- a/util/options.cc
+++ b/util/options.cc
@@ -26,4 +26,23 @@ Options::Options()
 }
 
 
+void
+Options::Dump(
+    Logger * log) const
+{
+    Log(log,"            Options.comparator: %p", comparator);
+    Log(log,"     Options.create_if_missing: %d", create_if_missing);
+    Log(log,"       Options.error_if_exists: %d", error_if_exists);
+    Log(log,"       Options.paranoid_checks: %d", paranoid_checks);
+    Log(log,"                   Options.env: %p", env);
+    Log(log,"              Options.info_log: %p", info_log);
+    Log(log,"     Options.write_buffer_size: %zd", write_buffer_size);
+    Log(log,"        Options.max_open_files: %d", max_open_files);
+    Log(log,"           Options.block_cache: %p", block_cache);
+    Log(log,"            Options.block_size: %d", block_size);
+    Log(log,"Options.block_restart_interval: %d", block_restart_interval);
+    Log(log,"         Options.filter_policy: %p", filter_policy);
+
+}   // Options::Dump
+
 }  // namespace leveldb


### PR DESCRIPTION
Diz requested that all options at the time of database open be placed in LOG to allow technical review.  This only logs global options, not the read and write specific options.
