### PR TITLE
Add multiple compaction threads with different task priorities.  Also mo...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build_config.mk
 *.so.*
 *_test
 db_bench
+*~

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -627,7 +627,7 @@ void DBImpl::MaybeScheduleCompaction() {
   }   // if
 
 
-  if (bg_compaction_scheduled_ && NULL==imm_) {
+  if (bg_compaction_scheduled_ && !push) {
     // Already scheduled
   } else if (shutting_down_.Acquire_Load()) {
     // DB is being deleted; no more background compactions

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -958,6 +958,11 @@ void VersionSet::Finalize(Version* v) {
       // overwrites/deletions).
       score = v->files_[level].size() /
           static_cast<double>(config::kL0_CompactionTrigger);
+
+      // don't screw around ... get data written to disk!
+      if (config::kL0_SlowdownWritesTrigger <= v->files_[level].size())
+          score*=10.0;
+
     } else {
       // Compute the ratio of current size to size limit.
       const uint64_t level_bytes = TotalFileSize(v->files_[level]);
@@ -1166,6 +1171,9 @@ Iterator* VersionSet::MakeInputIterator(Compaction* c) {
 Compaction* VersionSet::PickCompaction() {
   Compaction* c;
   int level;
+
+  // current_ could be really stale compared to state of files, recompute
+  Finalize(current_);
 
   // We prefer compactions triggered by too much data in a level over
   // the compactions triggered by seeks.

--- a/include/leveldb/env.h
+++ b/include/leveldb/env.h
@@ -123,7 +123,8 @@ class Env {
   // serialized.
   virtual void Schedule(
       void (*function)(void* arg),
-      void* arg) = 0;
+      void* arg,
+      int state=0) = 0;
 
   // Start a new thread, invoking "function(arg)" within the new thread.
   // When "function(arg)" returns, the thread will be destroyed.
@@ -205,7 +206,7 @@ class WritableFile {
   virtual ~WritableFile();
 
   virtual Status Append(const Slice& data) = 0;
-  virtual Status Close() = 0;
+  virtual Status Close(bool async=true) = 0;
   virtual Status Flush() = 0;
   virtual Status Sync() = 0;
 

--- a/util/env_posix.cc
+++ b/util/env_posix.cc
@@ -190,7 +190,9 @@ class PosixMmapFile : public WritableFile {
       BGCloseInfo * ptr=new BGCloseInfo(fd_, base_, file_offset_, limit_-base_, limit_-dst_);
       if (and_close)
       {
-          Env::Default()->Schedule(&BGFileCloser2, ptr, 4);
+          // do this in foreground unfortunately, bug where file not
+          //  closed fast enough for reopen
+          BGFileCloser2(ptr);
           fd_=-1;
       }   // if
       else
@@ -822,7 +824,7 @@ void BGFileUnmapper2(void * arg)
 
 // how many blocks of 3 priority background threads/queues
 /// for riak, make sure this is an odd number (and especially not 4)
-#define THREAD_BLOCKS 7
+#define THREAD_BLOCKS 3
 
 static pthread_once_t once = PTHREAD_ONCE_INIT;
 static Env* default_env[THREAD_BLOCKS];

--- a/util/env_posix.cc
+++ b/util/env_posix.cc
@@ -688,21 +688,11 @@ void PosixEnv::BGThread() {
   else
       queue_ptr=&queue_;
 
-  struct timeval now, wait;
-  struct timespec end;
-
-  wait.tv_sec=0;
-  wait.tv_usec=1000;
-
   while (true) {
     // Wait until there is an item that is ready to run
-      gettimeofday(&now, NULL);
     PthreadCall("lock", pthread_mutex_lock(&mu_));
     while (queue_ptr->empty()) {
-//      PthreadCall("wait", pthread_cond_wait(&bgsignal_, &mu_));
-        timeradd(&now, &wait, &now);
-        TIMEVAL_TO_TIMESPEC(&now, &end);
-        pthread_cond_timedwait(&bgsignal_, &mu_, &end);
+        PthreadCall("wait", pthread_cond_wait(&bgsignal_, &mu_));
     }
 
     void (*function)(void*) = queue_ptr->front().function;


### PR DESCRIPTION
...ve file close and unmap operations to background threads.  This update ends almost all stalls (subsequent cache checkin fixes low file handle stalls).  This can slow down throughput due to compactions happening as scheduled (subsequent file sizing addresses throughput).
