### PR TITLE
Clean up caching for better read speed and better size accounting.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build_config.mk
 *.so.*
 *_test
 db_bench
+*~

--- a/db/table_cache.cc
+++ b/db/table_cache.cc
@@ -38,7 +38,8 @@ TableCache::TableCache(const std::string& dbname,
 
       // convert file handle limit into a size limit
       //  based upon historical kTargetFileSize from version_set.cc
-      cache_(NewLRUCache2(entries * (2*1048576)))
+//      cache_(NewLRUCache2(entries * (2*1048576)))
+      cache_(NewLRUCache2(entries))
 {
 }
 
@@ -72,7 +73,8 @@ Status TableCache::FindTable(uint64_t file_number, uint64_t file_size,
       tf->file = file;
       tf->table = table;
 
-      *handle = cache_->Insert(key, tf, file_size, &DeleteEntry);
+//      *handle = cache_->Insert(key, tf, file_size, &DeleteEntry);
+      *handle = cache_->Insert(key, tf, 1, &DeleteEntry);
     }
   }
   return s;

--- a/db/table_cache.cc
+++ b/db/table_cache.cc
@@ -35,7 +35,11 @@ TableCache::TableCache(const std::string& dbname,
     : env_(options->env),
       dbname_(dbname),
       options_(options),
-      cache_(NewLRUCache(entries)) {
+
+      // convert file handle limit into a size limit
+      //  based upon historical kTargetFileSize from version_set.cc
+      cache_(NewLRUCache2(entries * (2*1048576)))
+{
 }
 
 TableCache::~TableCache() {
@@ -67,7 +71,8 @@ Status TableCache::FindTable(uint64_t file_number, uint64_t file_size,
       TableAndFile* tf = new TableAndFile;
       tf->file = file;
       tf->table = table;
-      *handle = cache_->Insert(key, tf, 1, &DeleteEntry);
+
+      *handle = cache_->Insert(key, tf, file_size, &DeleteEntry);
     }
   }
   return s;

--- a/include/leveldb/cache.h
+++ b/include/leveldb/cache.h
@@ -28,6 +28,7 @@ class Cache;
 // Create a new cache with a fixed size capacity.  This implementation
 // of Cache uses a least-recently-used eviction policy.
 extern Cache* NewLRUCache(size_t capacity);
+extern Cache* NewLRUCache2(size_t capacity);
 
 class Cache {
  public:
@@ -80,6 +81,10 @@ class Cache {
   // client will allocate a new id at startup and prepend the id to
   // its cache keys.
   virtual uint64_t NewId() = 0;
+
+  // Return size, if any, of per entry overhead for item placed in cache.
+  // Allows more accurate tracking of "charge" against each cache item.
+  virtual size_t EntryOverheadSize() {return(0);};
 
  private:
   void LRU_Remove(Handle* e);

--- a/port/port_posix.cc
+++ b/port/port_posix.cc
@@ -46,5 +46,17 @@ void CondVar::SignalAll() {
   PthreadCall("broadcast", pthread_cond_broadcast(&cv_));
 }
 
+
+RWMutex::RWMutex() { PthreadCall("init mutex", pthread_rwlock_init(&mu_, NULL)); }
+
+RWMutex::~RWMutex() { PthreadCall("destroy mutex", pthread_rwlock_destroy(&mu_)); }
+
+void RWMutex::ReadLock() { PthreadCall("read lock", pthread_rwlock_rdlock(&mu_)); }
+
+void RWMutex::WriteLock() { PthreadCall("write lock", pthread_rwlock_wrlock(&mu_)); }
+
+void RWMutex::Unlock() { PthreadCall("unlock", pthread_rwlock_unlock(&mu_)); }
+
+
 }  // namespace port
 }  // namespace leveldb

--- a/port/port_posix.h
+++ b/port/port_posix.h
@@ -99,6 +99,27 @@ class CondVar {
   Mutex* mu_;
 };
 
+
+class RWMutex {
+ public:
+  RWMutex();
+  ~RWMutex();
+
+  void ReadLock();
+  void WriteLock();
+  void Unlock();
+  void AssertHeld() { }
+
+ private:
+  pthread_rwlock_t mu_;
+
+  // No copying
+  RWMutex(const RWMutex&);
+  void operator=(const RWMutex&);
+
+};
+
+
 inline bool Snappy_Compress(const char* input, size_t length,
                             ::std::string* output) {
 #ifdef SNAPPY

--- a/table/table.cc
+++ b/table/table.cc
@@ -181,7 +181,9 @@ Iterator* Table::BlockReader(void* arg,
           block = new Block(contents);
           if (contents.cachable && options.fill_cache) {
             cache_handle = block_cache->Insert(
-                key, block, block->size(), &DeleteCachedBlock);
+                key, block,
+                (block->size() + block_cache->EntryOverheadSize() + sizeof(cache_key_buffer)),
+                &DeleteCachedBlock);
           }
         }
       }

--- a/util/mutexlock.h
+++ b/util/mutexlock.h
@@ -33,6 +33,36 @@ class MutexLock {
   void operator=(const MutexLock&);
 };
 
+
+class ReadLock {
+ public:
+  explicit ReadLock(port::RWMutex *mu) : mu_(mu) {
+    this->mu_->ReadLock();
+  }
+  ~ReadLock() { this->mu_->Unlock(); }
+
+ private:
+  port::RWMutex *const mu_;
+  // No copying allowed
+  ReadLock(const ReadLock&);
+  void operator=(const ReadLock&);
+};
+
+
+class WriteLock {
+ public:
+  explicit WriteLock(port::RWMutex *mu) : mu_(mu) {
+    this->mu_->WriteLock();
+  }
+  ~WriteLock() { this->mu_->Unlock(); }
+
+ private:
+  port::RWMutex *const mu_;
+  // No copying allowed
+  WriteLock(const WriteLock&);
+  void operator=(const WriteLock&);
+};
+
 }  // namespace leveldb
 
 


### PR DESCRIPTION
Following changes:
1. reader reader/writer lock objects for use with cache so GET operations can fly through quicker
2. changed LRU accounting from rearranging list on every read (which required write lock) to timestamp based
3. made LRUCache a proper subclass of Cache object so it could be used independently
4. table_cache now uses LRUCache instead of sharded cache because distribution of files across shards was highly uneven for low file counts (i.e. Riak usage) and caused stalls
5. block_cache now includes size of LRUHandle and key in its size accounting
