### PR TITLE
Adjustments to use much bigger .sst files for performance gains

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build_config.mk
 *.so.*
 *_test
 db_bench
+*~

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -20,11 +20,11 @@
 
 namespace leveldb {
 
-static const int kTargetFileSize = 2 * 1048576;
+static const int64_t kTargetFileSize = 60 * 1048576;
 
 // Maximum bytes of overlaps in grandparent (i.e., level+2) before we
 // stop building a single file in a level->level+1 compaction.
-static const int64_t kMaxGrandParentOverlapBytes = 10 * kTargetFileSize;
+static const int64_t kMaxGrandParentOverlapBytes = 25 * kTargetFileSize;
 
 // Maximum number of bytes in all compacted files.  We avoid expanding
 // the lower level file set of a compaction if it would make the
@@ -34,16 +34,17 @@ static const int64_t kExpandedCompactionByteSizeLimit = 25 * kTargetFileSize;
 static double MaxBytesForLevel(int level) {
   // Note: the result for level zero is not really used since we set
   // the level-0 compaction threshold based on number of files.
-  double result = 10 * 1048576.0;  // Result for both level-0 and level-1
+  double result = 200 * 1048576.0;
+  if (1==level) result*=2.0;
   while (level > 1) {
-    result *= 10;
+    result *= 10.0;
     level--;
   }
   return result;
 }
 
 static uint64_t MaxFileSizeForLevel(int level) {
-  return kTargetFileSize;  // We could vary per level to reduce number of files?
+  return(kTargetFileSize*(level+1)*5);
 }
 
 static int64_t TotalFileSize(const std::vector<FileMetaData*>& files) {

--- a/util/env_posix.cc
+++ b/util/env_posix.cc
@@ -192,7 +192,7 @@ class PosixMmapFile : public WritableFile {
       : filename_(fname),
         fd_(fd),
         page_size_(page_size),
-        map_size_(Roundup(65536, page_size)),
+        map_size_(Roundup(20 * 1048576, page_size)),
         base_(NULL),
         limit_(NULL),
         dst_(NULL),
@@ -329,6 +329,10 @@ class PosixEnv : public Env {
     int fd = open(fname.c_str(), O_RDONLY);
     if (fd < 0) {
       s = IOError(fname, errno);
+#if 0
+      // going to let page cache tune the file
+      //  system reads instead of hoping to better
+      //  manage through memory mapped files.
     } else if (sizeof(void*) >= 8) {
       // Use mmap when virtual address-space is plentiful.
       uint64_t size;
@@ -342,6 +346,7 @@ class PosixEnv : public Env {
         }
       }
       close(fd);
+#endif
     } else {
       *result = new PosixRandomAccessFile(fname, fd);
     }


### PR DESCRIPTION
This adjusts the internal file sizes and some code to use larger (not 2 Mbyte) files.  It also tunes the sizes of files at each level and totals for each level.  Raised throughput from 400 operations/second to 2,000 on test platform.
