### PR TITLE
tiered read/write lock

### DIFF
--- a/include/leveldb/env.h
+++ b/include/leveldb/env.h
@@ -345,6 +345,9 @@ class EnvWrapper : public Env {
   Env* target_;
 };
 
+extern pthread_rwlock_t gThreadLock0;
+extern pthread_rwlock_t gThreadLock1;
+
 }  // namespace leveldb
 
 #endif  // STORAGE_LEVELDB_INCLUDE_ENV_H_

--- a/util/env_posix.cc
+++ b/util/env_posix.cc
@@ -31,6 +31,9 @@
 
 namespace leveldb {
 
+pthread_rwlock_t gThreadLock0;
+pthread_rwlock_t gThreadLock1;
+
 namespace {
 
 static Status IOError(const std::string& context, int err_number) {
@@ -859,6 +862,10 @@ static void InitDefaultEnv()
     {
         default_env[loop]=new PosixEnv;
     }   // for
+
+    pthread_rwlock_init(&gThreadLock0, NULL);
+    pthread_rwlock_init(&gThreadLock1, NULL);
+
 }
 
 Env* Env::Default() {


### PR DESCRIPTION
use two read/write locks to establish global priorities for imm_ flush vs. level-0 merge vs. all other compactions.  gives disk write priorities in stated order.
