### PR TITLE
Mv badblock recovery

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -110,29 +110,6 @@ Options SanitizeOptions(const std::string& dbname,
     result.block_cache = NewLRUCache(8 << 20);
   }
 
-  if (NULL==result.bad_blocks)
-  {
-      std::string new_name;
-      WritableFile *bad_file;
-      Status s;
-
-      bad_file=NULL;
-      new_name=dbname;
-      new_name+="/lost";
-      src.env->CreateDir(new_name);
-      new_name+="/BLOCKS.bad";
-
-      s=src.env->NewAppendableFile(new_name, &bad_file);
-      if (s.ok())
-      {
-          result.bad_blocks=new log::Writer(bad_file);
-      }   // if
-      else
-      {
-          Log(result.info_log, "Unable to create file for bad/corrupted blocks: %s", new_name.c_str());
-      }   // else
-  }   // if
-
   return result;
 }
 
@@ -196,8 +173,6 @@ DBImpl::~DBImpl() {
   if (owns_cache_) {
     delete options_.block_cache;
   }
-  if (NULL != options_.bad_blocks) options_.bad_blocks->Close();
-  delete options_.bad_blocks;
 }
 
 Status DBImpl::NewDB() {

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1144,7 +1144,8 @@ Iterator* VersionSet::MakeInputIterator(Compaction* c) {
   options.fill_cache = false;
   options.is_compaction = true;
   options.info_log = options_->info_log;
-  options.bad_blocks = options_->GetBadBlocks();
+  options.dbname = dbname_;
+  options.env = env_;
 
   // Level-0 files have to be merged together.  For other levels,
   // we will make a concatenating iterator per level.

--- a/include/leveldb/options.h
+++ b/include/leveldb/options.h
@@ -6,6 +6,7 @@
 #define STORAGE_LEVELDB_INCLUDE_OPTIONS_H_
 
 #include <stddef.h>
+#include <string>
 
 namespace leveldb {
 
@@ -144,11 +145,6 @@ struct Options {
 
   void Dump(Logger * log) const;
 
-  // accessors
-  log::Writer * GetBadBlocks() const {return(bad_blocks);};
-
-  // These items below are internal options, not for external manipulation.
-  log::Writer * bad_blocks;
 };
 
 // Options that control read operations
@@ -175,7 +171,7 @@ struct ReadOptions {
       fill_cache(true),
       snapshot(NULL),
       is_compaction(false),
-      bad_blocks(NULL),
+      env(NULL),
       info_log(NULL)
   {
   }
@@ -184,10 +180,11 @@ struct ReadOptions {
   // accessors to the private data
   bool IsCompaction() const {return(is_compaction);};
 
-  log::Writer * GetBadBlocks() const {return(bad_blocks);};
-
   Logger * GetInfoLog() const {return(info_log);};
 
+  const std::string & GetDBName() const {return(dbname);};
+
+  Env * GetEnv() const {return(env);};
 
   // The items below are internal options, not for external manipulation.
   //  They are populated by VersionSet::MakeInputIterator only during compaction operations
@@ -197,9 +194,11 @@ private:
   // true when used on background compaction
   bool is_compaction;
 
-  // File to receive corrupted blocks found during compaction.
-  // Only valid when is_compation==true
-  log::Writer * bad_blocks;
+  // Database name for potential creation of bad blocks file
+  std::string dbname;
+
+  // Needed for file operations if creating bad blocks file
+  Env * env;
 
   // Open log file for error notifications
   // Only valid when is_compation==true

--- a/util/env_posix.cc
+++ b/util/env_posix.cc
@@ -219,6 +219,13 @@ class PosixMmapFile : public WritableFile {
   }
 
   bool MapNewRegion() {
+    size_t offset_adjust;
+
+    // append mode file might not have file_offset_ on a page boundry
+    offset_adjust=file_offset_ % page_size_;
+    if (0!=offset_adjust)
+        file_offset_-=offset_adjust;
+
     assert(base_ == NULL);
     if (ftruncate(fd_, file_offset_ + map_size_) < 0) {
       return false;
@@ -230,7 +237,7 @@ class PosixMmapFile : public WritableFile {
     }
     base_ = reinterpret_cast<char*>(ptr);
     limit_ = base_ + map_size_;
-    dst_ = base_;
+    dst_ = base_ + offset_adjust;
     last_sync_ = base_;
     return true;
   }

--- a/util/options.cc
+++ b/util/options.cc
@@ -23,8 +23,7 @@ Options::Options()
       block_size(4096),
       block_restart_interval(16),
       compression(kSnappyCompression),
-      filter_policy(NULL),
-      bad_blocks(NULL)
+      filter_policy(NULL)
 {
 }
 


### PR DESCRIPTION
Rewrite to make BLOCKS.bad file only appear upon first use and only be open when actively saving off a bad block.
