### PR TITLE
Added solaris-specific version of the ref counting atomics

### DIFF
--- a/util/cache.cc
+++ b/util/cache.cc
@@ -12,6 +12,10 @@
 #include "util/hash.h"
 #include "util/mutexlock.h"
 
+#ifdef OS_SOLARIS
+#  include <atomic.h>
+#endif
+
 namespace leveldb {
 
 Cache::~Cache() {
@@ -263,7 +267,11 @@ Cache::Handle* LRUCache::Lookup(const Slice& key, uint32_t hash) {
   e = table_.Lookup(key, hash);
 
   if (e != NULL) {
+#ifdef OS_SOLARIS
+    atomic_add_int(&e->refs, 1);
+#else
     __sync_add_and_fetch(&e->refs, 1);
+#endif
     // was ... e->refs++;
     gettimeofday(&e->last_access, NULL);
   }


### PR DESCRIPTION
Resolves

```
c++ -D_REENTRANT -m64  -fPIC -I /export/home/buildbot/masters/riak/riak_ee-build-solaris-10u9-64/build/deps/eleveldb/c_src/system/include -I. -I./include -fno-builtin-memcmp -D_REENTRANT -DOS_SOLARIS -DLEVELDB_PLATFORM_POSIX -DSNAPPY -O2 -DNDEBUG        -fPIC -c util/cache.cc -o util/cache.o
util/cache.cc: In member function `leveldb::Cache::Handle* leveldb::::LRUCache::Lookup(const leveldb::Slice&, uint32_t)':
util/cache.cc:266: error: `__sync_add_and_fetch' undeclared (first use this function)
util/cache.cc:266: error: (Each undeclared identifier is reported only once for each function it appears in.)
```

Passes Joe's C++ crasher (and verified it crashed before).
