### PR TITLE
Asynchronous write buffers to improve compaction by 14 to to 19%

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,8 @@ TESTS = \
 	write_batch_test
 
 TOOLS = \
-	sst_scan
+	sst_scan \
+	bloom_scan
 
 PROGRAMS = db_bench $(TESTS) $(TOOLS)
 BENCHMARKS = db_bench_sqlite3 db_bench_tree_db
@@ -105,6 +106,9 @@ clean:
 $(LIBRARY): $(LIBOBJECTS)
 	rm -f $@
 	$(AR) -rs $@ $(LIBOBJECTS)
+
+bloom_scan: tools/bloom_scan.o $(LIBOBJECTS)
+	$(CXX) tools/bloom_scan.o $(LIBOBJECTS) -o $@ $(LDFLAGS)
 
 db_bench: db/db_bench.o $(LIBOBJECTS) $(TESTUTIL)
 	$(CXX) db/db_bench.o $(LIBOBJECTS) $(TESTUTIL) -o $@  $(LDFLAGS)

--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,9 @@ $(LIBRARY): $(LIBOBJECTS)
 	rm -f $@
 	$(AR) -rs $@ $(LIBOBJECTS)
 
+bloom_scan: tools/bloom_scan.o $(LIBOBJECTS)
+	$(CXX) tools/bloom_scan.o $(LIBOBJECTS) -o $@ $(LDFLAGS)
+
 db_bench: db/db_bench.o $(LIBOBJECTS) $(TESTUTIL)
 	$(CXX) db/db_bench.o $(LIBOBJECTS) $(TESTUTIL) -o $@  $(LDFLAGS)
 

--- a/db/builder.cc
+++ b/db/builder.cc
@@ -12,6 +12,7 @@
 #include "leveldb/env.h"
 #include "leveldb/iterator.h"
 #include "table/table_builder2.h"
+#include "util/mapbuffer.h"
 
 namespace leveldb {
 
@@ -37,7 +38,14 @@ Status BuildTable(const std::string& dbname,
       return s;
     }
 
-    TableBuilder* builder = new TableBuilder2(options, file);
+    // not all file systems (such as the memenv) support Allocate()
+    TableBuilder * builder;
+    RiakBufferPtr temp_ptr;
+    if (file->SupportsBuilder2())
+        builder = new TableBuilder2(options, file);
+    else
+        builder = new TableBuilder(options, file);
+
     meta->smallest.DecodeFrom(iter->key());
     for (; iter->Valid(); iter->Next()) {
       Slice key = iter->key();

--- a/db/builder.cc
+++ b/db/builder.cc
@@ -11,6 +11,7 @@
 #include "leveldb/db.h"
 #include "leveldb/env.h"
 #include "leveldb/iterator.h"
+#include "table/table_builder2.h"
 
 namespace leveldb {
 
@@ -36,7 +37,7 @@ Status BuildTable(const std::string& dbname,
       return s;
     }
 
-    TableBuilder* builder = new TableBuilder(options, file);
+    TableBuilder* builder = new TableBuilder2(options, file);
     meta->smallest.DecodeFrom(iter->key());
     for (; iter->Valid(); iter->Next()) {
       Slice key = iter->key();

--- a/db/builder.cc
+++ b/db/builder.cc
@@ -31,7 +31,7 @@ Status BuildTable(const std::string& dbname,
   std::string fname = TableFileName(dbname, meta->number);
   if (iter->Valid()) {
     WritableFile* file;
-    s = env->NewWritableFile(fname, &file);
+    s = env->NewWritableFile(fname, &file, true, options.write_buffer_size);
     if (!s.ok()) {
       return s;
     }
@@ -62,10 +62,16 @@ Status BuildTable(const std::string& dbname,
 
     // Finish and check for file errors
     if (s.ok()) {
+    uint64_t timer=options.env->NowMicros();
       s = file->Sync();
+    timer=options.env->NowMicros()-timer;
+    Log(options.info_log, "Sync() micros: %llu", (unsigned long long)timer);
     }
     if (s.ok()) {
+    uint64_t timer=options.env->NowMicros();
       s = file->Close();
+    timer=options.env->NowMicros()-timer;
+    Log(options.info_log, "Close() micros: %llu", (unsigned long long)timer);
     }
     delete file;
     file = NULL;

--- a/db/builder.cc
+++ b/db/builder.cc
@@ -32,7 +32,7 @@ Status BuildTable(const std::string& dbname,
   std::string fname = TableFileName(dbname, meta->number, meta->level);
   if (iter->Valid()) {
     WritableFile* file;
-    s = env->NewWritableFile(fname, &file);
+    s = env->NewWritableFile(fname, &file, true, options.write_buffer_size);
     if (!s.ok()) {
       return s;
     }
@@ -63,10 +63,16 @@ Status BuildTable(const std::string& dbname,
 
     // Finish and check for file errors
     if (s.ok()) {
+    uint64_t timer=options.env->NowMicros();
       s = file->Sync();
+    timer=options.env->NowMicros()-timer;
+    Log(options.info_log, "Sync() micros: %llu", (unsigned long long)timer);
     }
     if (s.ok()) {
+    uint64_t timer=options.env->NowMicros();
       s = file->Close();
+    timer=options.env->NowMicros()-timer;
+    Log(options.info_log, "Close() micros: %llu", (unsigned long long)timer);
     }
     delete file;
     file = NULL;

--- a/db/builder.cc
+++ b/db/builder.cc
@@ -11,6 +11,7 @@
 #include "leveldb/db.h"
 #include "leveldb/env.h"
 #include "leveldb/iterator.h"
+#include "table/table_builder2.h"
 
 namespace leveldb {
 
@@ -35,7 +36,7 @@ Status BuildTable(const std::string& dbname,
       return s;
     }
 
-    TableBuilder* builder = new TableBuilder(options, file);
+    TableBuilder* builder = new TableBuilder2(options, file);
     meta->smallest.DecodeFrom(iter->key());
     for (; iter->Valid(); iter->Next()) {
       Slice key = iter->key();

--- a/db/builder.cc
+++ b/db/builder.cc
@@ -42,7 +42,7 @@ Status BuildTable(const std::string& dbname,
     TableBuilder * builder;
     RiakBufferPtr temp_ptr;
     if (file->SupportsBuilder2())
-        builder = new TableBuilder2(options, file);
+        builder = new TableBuilder2(options, file, meta->level);
     else
         builder = new TableBuilder(options, file);
 

--- a/db/corruption_test.cc
+++ b/db/corruption_test.cc
@@ -4,6 +4,7 @@
 
 #include "leveldb/db.h"
 
+#include <unistd.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <sys/stat.h>
@@ -327,6 +328,7 @@ TEST(CorruptionTest, CompactionInputErrorParanoid) {
     dbi->Put(WriteOptions(), "", "begin");
     dbi->Put(WriteOptions(), "~", "end");
     dbi->TEST_CompactMemTable();
+    sleep(1);  // becomes a race with background compaction without sleep
   }
 
   Build(10);

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -822,7 +822,8 @@ Status DBImpl::OpenCompactionOutputFile(CompactionState* compact) {
 
   // Make the output file
   std::string fname = TableFileName(dbname_, file_number);
-  Status s = env_->NewWritableFile(fname, &compact->outfile);
+  Status s = env_->NewWritableFile(fname, &compact->outfile,
+                                   compact->compaction->level()<2, options_.write_buffer_size);
   if (s.ok()) {
     compact->builder = new TableBuilder2(options_, compact->outfile);
   }
@@ -855,10 +856,16 @@ Status DBImpl::FinishCompactionOutputFile(CompactionState* compact,
 
   // Finish and check for file errors
   if (s.ok()) {
+      uint64_t timer=options_.env->NowMicros();
     s = compact->outfile->Sync();
+    timer=options_.env->NowMicros()-timer;
+    Log(options_.info_log, "Sync() micros: %llu", (unsigned long long)timer);
   }
   if (s.ok()) {
+      uint64_t timer=options_.env->NowMicros();
     s = compact->outfile->Close();
+    timer=options_.env->NowMicros()-timer;
+    Log(options_.info_log, "Close() micros: %llu", (unsigned long long)timer);
   }
   delete compact->outfile;
   compact->outfile = NULL;
@@ -938,6 +945,8 @@ Status DBImpl::DoCompactionWork(CompactionState* compact) {
 
   KeyRetirement retire(user_comparator(), compact->smallest_snapshot, compact->compaction);
 
+  uint64_t read_timer(0), write_timer(0), timer(0);
+
   for (; input->Valid() && !shutting_down_.Acquire_Load(); )
   {
     // Prioritize immutable compaction work
@@ -967,7 +976,10 @@ Status DBImpl::DoCompactionWork(CompactionState* compact) {
         compact->current_output()->smallest.DecodeFrom(key);
       }
       compact->current_output()->largest.DecodeFrom(key);
+
+      timer=env_->NowMicros();
       compact->builder->Add(key, input->value());
+      write_timer+=env_->NowMicros() - timer;
 
       // Close output file if it is big enough
       if (compact->builder->FileSize() >=
@@ -979,7 +991,9 @@ Status DBImpl::DoCompactionWork(CompactionState* compact) {
       }
     }
 
+    timer=env_->NowMicros();
     input->Next();
+    read_timer+=env_->NowMicros() - timer;
   }
 
   if (status.ok() && shutting_down_.Acquire_Load()) {
@@ -1019,6 +1033,8 @@ Status DBImpl::DoCompactionWork(CompactionState* compact) {
   VersionSet::LevelSummaryStorage tmp;
   Log(options_.info_log,
       "compacted to: %s", versions_->LevelSummary(&tmp));
+  Log(options_.info_log, "Read micros: %llu, Write micros: %llu",
+      (unsigned long long)read_timer, (unsigned long long)write_timer);
   return status;
 }
 

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -948,7 +948,7 @@ Status DBImpl::OpenCompactionOutputFile(CompactionState* compact) {
                                    compact->compaction->level()<2, options_.write_buffer_size);
 
   if (s.ok()) {
-    compact->builder = new TableBuilder2(options_, compact->outfile);
+      compact->builder = new TableBuilder2(options_, compact->outfile, compact->compaction->level()+1);
   }
   return s;
 }

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -31,6 +31,7 @@
 #include "port/port.h"
 #include "table/block.h"
 #include "table/merger.h"
+#include "table/table_builder2.h"
 #include "table/two_level_iterator.h"
 #include "util/coding.h"
 #include "util/logging.h"
@@ -945,7 +946,7 @@ Status DBImpl::OpenCompactionOutputFile(CompactionState* compact) {
   std::string fname = TableFileName(dbname_, file_number, compact->compaction->level()+1);
   Status s = env_->NewWritableFile(fname, &compact->outfile);
   if (s.ok()) {
-    compact->builder = new TableBuilder(options_, compact->outfile);
+    compact->builder = new TableBuilder2(options_, compact->outfile);
   }
   return s;
 }

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -31,6 +31,7 @@
 #include "port/port.h"
 #include "table/block.h"
 #include "table/merger.h"
+#include "table/table_builder2.h"
 #include "table/two_level_iterator.h"
 #include "util/coding.h"
 #include "util/logging.h"
@@ -823,7 +824,7 @@ Status DBImpl::OpenCompactionOutputFile(CompactionState* compact) {
   std::string fname = TableFileName(dbname_, file_number);
   Status s = env_->NewWritableFile(fname, &compact->outfile);
   if (s.ok()) {
-    compact->builder = new TableBuilder(options_, compact->outfile);
+    compact->builder = new TableBuilder2(options_, compact->outfile);
   }
   return s;
 }

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -944,7 +944,9 @@ Status DBImpl::OpenCompactionOutputFile(CompactionState* compact) {
 
   // Make the output file
   std::string fname = TableFileName(dbname_, file_number, compact->compaction->level()+1);
-  Status s = env_->NewWritableFile(fname, &compact->outfile);
+  Status s = env_->NewWritableFile(fname, &compact->outfile,
+                                   compact->compaction->level()<2, options_.write_buffer_size);
+
   if (s.ok()) {
     compact->builder = new TableBuilder2(options_, compact->outfile);
   }
@@ -977,10 +979,16 @@ Status DBImpl::FinishCompactionOutputFile(CompactionState* compact,
 
   // Finish and check for file errors
   if (s.ok()) {
+      uint64_t timer=options_.env->NowMicros();
     s = compact->outfile->Sync();
+    timer=options_.env->NowMicros()-timer;
+    Log(options_.info_log, "Sync() micros: %llu", (unsigned long long)timer);
   }
   if (s.ok()) {
+      uint64_t timer=options_.env->NowMicros();
     s = compact->outfile->Close();
+    timer=options_.env->NowMicros()-timer;
+    Log(options_.info_log, "Close() micros: %llu", (unsigned long long)timer);
   }
   delete compact->outfile;
   compact->outfile = NULL;
@@ -1063,6 +1071,8 @@ Status DBImpl::DoCompactionWork(CompactionState* compact) {
 
   KeyRetirement retire(user_comparator(), compact->smallest_snapshot, compact->compaction);
 
+  uint64_t read_timer(0), write_timer(0), timer(0);
+
   for (; input->Valid() && !shutting_down_.Acquire_Load(); )
   {
     // Prioritize immutable compaction work
@@ -1092,7 +1102,10 @@ Status DBImpl::DoCompactionWork(CompactionState* compact) {
         compact->current_output()->smallest.DecodeFrom(key);
       }
       compact->current_output()->largest.DecodeFrom(key);
+
+      timer=env_->NowMicros();
       compact->builder->Add(key, input->value());
+      write_timer+=env_->NowMicros() - timer;
 
       // update throttle ... now, end of compaction may be too late
       //   but not too often since NowMicros can be costly
@@ -1128,7 +1141,9 @@ Status DBImpl::DoCompactionWork(CompactionState* compact) {
       }
     }
 
+    timer=env_->NowMicros();
     input->Next();
+    read_timer+=env_->NowMicros() - timer;
   }
 
   if (status.ok() && shutting_down_.Acquire_Load()) {
@@ -1171,6 +1186,8 @@ Status DBImpl::DoCompactionWork(CompactionState* compact) {
   VersionSet::LevelSummaryStorage tmp;
   Log(options_.info_log,
       "compacted to: %s", versions_->LevelSummary(&tmp));
+  Log(options_.info_log, "Read micros: %llu, Write micros: %llu",
+      (unsigned long long)read_timer, (unsigned long long)write_timer);
   return status;
 }
 

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -31,6 +31,7 @@
 #include "port/port.h"
 #include "table/block.h"
 #include "table/merger.h"
+#include "table/table_builder2.h"
 #include "table/two_level_iterator.h"
 #include "util/coding.h"
 #include "util/logging.h"
@@ -937,7 +938,7 @@ Status DBImpl::OpenCompactionOutputFile(CompactionState* compact) {
   std::string fname = TableFileName(dbname_, file_number, compact->compaction->level()+1);
   Status s = env_->NewWritableFile(fname, &compact->outfile);
   if (s.ok()) {
-    compact->builder = new TableBuilder(options_, compact->outfile);
+    compact->builder = new TableBuilder2(options_, compact->outfile);
   }
   return s;
 }

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -936,7 +936,8 @@ Status DBImpl::OpenCompactionOutputFile(CompactionState* compact) {
 
   // Make the output file
   std::string fname = TableFileName(dbname_, file_number, compact->compaction->level()+1);
-  Status s = env_->NewWritableFile(fname, &compact->outfile);
+  Status s = env_->NewWritableFile(fname, &compact->outfile,
+                                   compact->compaction->level()<2, options_.write_buffer_size);
   if (s.ok()) {
     compact->builder = new TableBuilder2(options_, compact->outfile);
   }
@@ -969,10 +970,16 @@ Status DBImpl::FinishCompactionOutputFile(CompactionState* compact,
 
   // Finish and check for file errors
   if (s.ok()) {
+      uint64_t timer=options_.env->NowMicros();
     s = compact->outfile->Sync();
+    timer=options_.env->NowMicros()-timer;
+    Log(options_.info_log, "Sync() micros: %llu", (unsigned long long)timer);
   }
   if (s.ok()) {
+      uint64_t timer=options_.env->NowMicros();
     s = compact->outfile->Close();
+    timer=options_.env->NowMicros()-timer;
+    Log(options_.info_log, "Close() micros: %llu", (unsigned long long)timer);
   }
   delete compact->outfile;
   compact->outfile = NULL;
@@ -1053,6 +1060,8 @@ Status DBImpl::DoCompactionWork(CompactionState* compact) {
 
   KeyRetirement retire(user_comparator(), compact->smallest_snapshot, compact->compaction);
 
+  uint64_t read_timer(0), write_timer(0), timer(0);
+
   for (; input->Valid() && !shutting_down_.Acquire_Load(); )
   {
     // Prioritize immutable compaction work
@@ -1082,7 +1091,10 @@ Status DBImpl::DoCompactionWork(CompactionState* compact) {
         compact->current_output()->smallest.DecodeFrom(key);
       }
       compact->current_output()->largest.DecodeFrom(key);
+
+      timer=env_->NowMicros();
       compact->builder->Add(key, input->value());
+      write_timer+=env_->NowMicros() - timer;
 
       // Close output file if it is big enough
       if (compact->builder->FileSize() >=
@@ -1094,7 +1106,9 @@ Status DBImpl::DoCompactionWork(CompactionState* compact) {
       }
     }
 
+    timer=env_->NowMicros();
     input->Next();
+    read_timer+=env_->NowMicros() - timer;
   }
 
   if (status.ok() && shutting_down_.Acquire_Load()) {
@@ -1134,6 +1148,8 @@ Status DBImpl::DoCompactionWork(CompactionState* compact) {
   VersionSet::LevelSummaryStorage tmp;
   Log(options_.info_log,
       "compacted to: %s", versions_->LevelSummary(&tmp));
+  Log(options_.info_log, "Read micros: %llu, Write micros: %llu",
+      (unsigned long long)read_timer, (unsigned long long)write_timer);
   return status;
 }
 

--- a/db/dbformat.cc
+++ b/db/dbformat.cc
@@ -119,10 +119,6 @@ void InternalFilterPolicy::CreateFilter(const Slice* keys, int n,
   // We rely on the fact that the code in table.cc does not mind us
   // adjusting keys[].
   Slice* mkey = const_cast<Slice*>(keys);
-  for (int i = 0; i < n; i++) {
-    mkey[i] = ExtractUserKey(keys[i]);
-    // TODO(sanjay): Suppress dups?
-  }
   user_policy_->CreateFilter(keys, n, dst);
 }
 

--- a/db/dbformat.cc
+++ b/db/dbformat.cc
@@ -108,10 +108,6 @@ void InternalFilterPolicy::CreateFilter(const Slice* keys, int n,
   // We rely on the fact that the code in table.cc does not mind us
   // adjusting keys[].
   Slice* mkey = const_cast<Slice*>(keys);
-  for (int i = 0; i < n; i++) {
-    mkey[i] = ExtractUserKey(keys[i]);
-    // TODO(sanjay): Suppress dups?
-  }
   user_policy_->CreateFilter(keys, n, dst);
 }
 

--- a/db/dbformat.cc
+++ b/db/dbformat.cc
@@ -118,11 +118,10 @@ void InternalFilterPolicy::CreateFilter(const Slice* keys, int n,
                                         std::string* dst) const {
   // We rely on the fact that the code in table.cc does not mind us
   // adjusting keys[].
-  Slice* mkey = const_cast<Slice*>(keys);
   user_policy_->CreateFilter(keys, n, dst);
 }
 
-    Slice InternalFilterPolicy::TransformKey(const Slice & Key, std::string & Buffer) const {
+Slice InternalFilterPolicy::TransformKey(const Slice & Key, std::string & Buffer) const {
   return user_policy_->TransformKey(ExtractUserKey(Key), Buffer);
 }
 

--- a/db/dbformat.cc
+++ b/db/dbformat.cc
@@ -122,6 +122,10 @@ void InternalFilterPolicy::CreateFilter(const Slice* keys, int n,
   user_policy_->CreateFilter(keys, n, dst);
 }
 
+    Slice InternalFilterPolicy::TransformKey(const Slice & Key, std::string & Buffer) const {
+  return user_policy_->TransformKey(ExtractUserKey(Key), Buffer);
+}
+
 bool InternalFilterPolicy::KeyMayMatch(const Slice& key, const Slice& f) const {
   return user_policy_->KeyMayMatch(ExtractUserKey(key), f);
 }

--- a/db/dbformat.h
+++ b/db/dbformat.h
@@ -135,6 +135,7 @@ class InternalFilterPolicy : public FilterPolicy {
   explicit InternalFilterPolicy(const FilterPolicy* p) : user_policy_(p) { }
   virtual const char* Name() const;
   virtual void CreateFilter(const Slice* keys, int n, std::string* dst) const;
+  virtual Slice TransformKey(const Slice & Key, std::string & Buffer) const;
   virtual bool KeyMayMatch(const Slice& key, const Slice& filter) const;
 };
 

--- a/helpers/memenv/memenv.cc
+++ b/helpers/memenv/memenv.cc
@@ -257,7 +257,10 @@ class InMemoryEnv : public EnvWrapper {
   }
 
   virtual Status NewWritableFile(const std::string& fname,
-                                 WritableFile** result) {
+                                 WritableFile** result,
+                                 bool AdviseKeep=false,
+                                 const size_t WriteBufferSize=0)
+ {
     MutexLock lock(&mutex_);
     if (file_map_.find(fname) != file_map_.end()) {
       DeleteFileInternal(fname);

--- a/include/leveldb/env.h
+++ b/include/leveldb/env.h
@@ -28,6 +28,7 @@ class SequentialFile;
 class Slice;
 class WritableFile;
 class AppendableFile;
+class RiakBufferPtr;
 
 class Env {
  public:
@@ -227,6 +228,7 @@ class WritableFile {
   virtual Status Close() = 0;
   virtual Status Flush() = 0;
   virtual Status Sync() = 0;
+  virtual Status Allocate(size_t, RiakBufferPtr&) {return(Status::NotSupported("WritableFile::Allocate() not supported"));};
 
  private:
   // No copying allowed

--- a/include/leveldb/env.h
+++ b/include/leveldb/env.h
@@ -245,6 +245,7 @@ class WritableFile {
   virtual Status Flush() = 0;
   virtual Status Sync() = 0;
   virtual Status Allocate(size_t, RiakBufferPtr&) {return(Status::NotSupported("WritableFile::Allocate() not supported"));};
+  virtual bool SupportsBuilder2() const {return(false);};
 
  private:
   // No copying allowed

--- a/include/leveldb/env.h
+++ b/include/leveldb/env.h
@@ -29,6 +29,7 @@ class SequentialFile;
 class Slice;
 class WritableFile;
 class AppendableFile;
+class RiakBufferPtr;
 
 class Env {
  public:
@@ -243,6 +244,7 @@ class WritableFile {
   virtual Status Close() = 0;
   virtual Status Flush() = 0;
   virtual Status Sync() = 0;
+  virtual Status Allocate(size_t, RiakBufferPtr&) {return(Status::NotSupported("WritableFile::Allocate() not supported"));};
 
  private:
   // No copying allowed

--- a/include/leveldb/env.h
+++ b/include/leveldb/env.h
@@ -68,7 +68,9 @@ class Env {
   //
   // The returned file will only be accessed by one thread at a time.
   virtual Status NewWritableFile(const std::string& fname,
-                                 WritableFile** result) = 0;
+                                 WritableFile** result,
+                                 bool AdviseKeep=false,
+                                 const size_t WriteBufferSize=0) = 0;
 
   // Derived from NewWritableFile.  One change: if the file exists,
   // move to the end of the file and continue writing.

--- a/include/leveldb/env.h
+++ b/include/leveldb/env.h
@@ -28,6 +28,7 @@ class SequentialFile;
 class Slice;
 class WritableFile;
 class AppendableFile;
+class RiakBufferPtr;
 
 class Env {
  public:
@@ -226,6 +227,7 @@ class WritableFile {
   virtual Status Close() = 0;
   virtual Status Flush() = 0;
   virtual Status Sync() = 0;
+  virtual Status Allocate(size_t, RiakBufferPtr&) {return(Status::NotSupported("WritableFile::Allocate() not supported"));};
 
  private:
   // No copying allowed

--- a/include/leveldb/env.h
+++ b/include/leveldb/env.h
@@ -69,7 +69,9 @@ class Env {
   //
   // The returned file will only be accessed by one thread at a time.
   virtual Status NewWritableFile(const std::string& fname,
-                                 WritableFile** result) = 0;
+                                 WritableFile** result,
+                                 bool AdviseKeep=false,
+                                 const size_t WriteBufferSize=0) = 0;
 
   // Derived from NewWritableFile.  One change: if the file exists,
   // move to the end of the file and continue writing.

--- a/include/leveldb/filter_policy.h
+++ b/include/leveldb/filter_policy.h
@@ -53,6 +53,10 @@ public:
   virtual void CreateFilter(const Slice* keys, int n, std::string* dst)
       const = 0;
 
+  // Allow filter to preprocess keys being held for CreateFilter ... reducing
+  //  storage
+  virtual Slice TransformKey(const Slice & Key, std::string & Buffer) const;
+
   // "filter" contains the data appended by a preceding call to
   // CreateFilter() on this class.  This method must return true if
   // the key was in the list of keys passed to CreateFilter().

--- a/include/leveldb/filter_policy.h
+++ b/include/leveldb/filter_policy.h
@@ -55,7 +55,7 @@ public:
 
   // Allow filter to preprocess keys being held for CreateFilter ... reducing
   //  storage
-  virtual Slice TransformKey(const Slice & Key, std::string & Buffer) const;
+  virtual Slice TransformKey(const Slice & Key, std::string & Buffer) const = 0;
 
   // "filter" contains the data appended by a preceding call to
   // CreateFilter() on this class.  This method must return true if

--- a/include/leveldb/filter_policy.h
+++ b/include/leveldb/filter_policy.h
@@ -41,6 +41,10 @@ class FilterPolicy {
   virtual void CreateFilter(const Slice* keys, int n, std::string* dst)
       const = 0;
 
+  // Allow filter to preprocess keys being held for CreateFilter ... reducing
+  //  storage
+  virtual Slice TransformKey(const Slice & Key, std::string & Buffer) const;
+
   // "filter" contains the data appended by a preceding call to
   // CreateFilter() on this class.  This method must return true if
   // the key was in the list of keys passed to CreateFilter().

--- a/include/leveldb/table_builder.h
+++ b/include/leveldb/table_builder.h
@@ -31,7 +31,7 @@ class TableBuilder {
   TableBuilder(const Options& options, WritableFile* file);
 
   // REQUIRES: Either Finish() or Abandon() has been called.
-  ~TableBuilder();
+  virtual ~TableBuilder();
 
   // Change the options used by this builder.  Note: only some of the
   // option fields can be changed after construction.  If a field is
@@ -44,13 +44,13 @@ class TableBuilder {
   // Add key,value to the table being constructed.
   // REQUIRES: key is after any previously added key according to comparator.
   // REQUIRES: Finish(), Abandon() have not been called
-  void Add(const Slice& key, const Slice& value);
+  virtual void Add(const Slice& key, const Slice& value);
 
   // Advanced operation: flush any buffered key/value pairs to file.
   // Can be used to ensure that two adjacent entries never live in
   // the same data block.  Most clients should not need to use this method.
   // REQUIRES: Finish(), Abandon() have not been called
-  void Flush();
+  virtual void Flush();
 
   // Return non-ok iff some error has been detected.
   Status status() const;
@@ -58,14 +58,14 @@ class TableBuilder {
   // Finish building the table.  Stops using the file passed to the
   // constructor after this function returns.
   // REQUIRES: Finish(), Abandon() have not been called
-  Status Finish();
+  virtual Status Finish();
 
   // Indicate that the contents of this builder should be abandoned.  Stops
   // using the file passed to the constructor after this function returns.
   // If the caller is not going to call Finish(), it must call Abandon()
   // before destroying this builder.
   // REQUIRES: Finish(), Abandon() have not been called
-  void Abandon();
+  virtual void Abandon();
 
   // Number of calls to Add() so far.
   uint64_t NumEntries() const;
@@ -74,7 +74,7 @@ class TableBuilder {
   // Finish() call, returns the size of the final generated file.
   uint64_t FileSize() const;
 
- private:
+protected:
   bool ok() const { return status().ok(); }
   void WriteBlock(BlockBuilder* block, BlockHandle* handle);
   void WriteRawBlock(const Slice& data, CompressionType, BlockHandle* handle);
@@ -82,6 +82,7 @@ class TableBuilder {
   struct Rep;
   Rep* rep_;
 
+private:
   // No copying allowed
   TableBuilder(const TableBuilder&);
   void operator=(const TableBuilder&);

--- a/port/port_posix.cc
+++ b/port/port_posix.cc
@@ -27,6 +27,16 @@ void Mutex::Lock() { PthreadCall("lock", pthread_mutex_lock(&mu_)); }
 
 void Mutex::Unlock() { PthreadCall("unlock", pthread_mutex_unlock(&mu_)); }
 
+
+MutexLock::MutexLock(Mutex & Mu) : mu_(Mu) {mu_.Lock();}
+
+MutexLock::~MutexLock() { mu_.Unlock();}
+
+void MutexLock::Lock() { mu_.Lock();}
+
+void MutexLock::Unlock() { mu_.Unlock();}
+
+
 CondVar::CondVar(Mutex* mu)
     : mu_(mu) {
     PthreadCall("init cv", pthread_cond_init(&cv_, NULL));

--- a/port/port_posix.h
+++ b/port/port_posix.h
@@ -87,6 +87,26 @@ class Mutex {
   void operator=(const Mutex&);
 };
 
+
+class MutexLock {
+ public:
+  MutexLock(Mutex & mu);
+  ~MutexLock();
+
+  void Lock();
+  void Unlock();
+  void AssertHeld() { }
+
+ private:
+  Mutex & mu_;
+
+  MutexLock();
+  // No copying
+  MutexLock(const MutexLock &);
+  void operator=(const MutexLock &);
+};
+
+
 class CondVar {
  public:
   explicit CondVar(Mutex* mu);

--- a/port/port_posix.h
+++ b/port/port_posix.h
@@ -102,6 +102,26 @@ class Mutex {
   void operator=(const Mutex&);
 };
 
+
+class MutexLock {
+ public:
+  MutexLock(Mutex & mu);
+  ~MutexLock();
+
+  void Lock();
+  void Unlock();
+  void AssertHeld() { }
+
+ private:
+  Mutex & mu_;
+
+  MutexLock();
+  // No copying
+  MutexLock(const MutexLock &);
+  void operator=(const MutexLock &);
+};
+
+
 class CondVar {
  public:
   explicit CondVar(Mutex* mu);

--- a/table/block_builder.cc
+++ b/table/block_builder.cc
@@ -36,6 +36,13 @@
 
 namespace leveldb {
 
+
+BlockBuilder::BlockBuilder()
+{
+    options_=NULL;
+    Reset();
+}   
+
 BlockBuilder::BlockBuilder(const Options* options)
     : options_(options),
       restarts_(),

--- a/table/block_builder.h
+++ b/table/block_builder.h
@@ -16,7 +16,11 @@ struct Options;
 
 class BlockBuilder {
  public:
+  BlockBuilder();
   explicit BlockBuilder(const Options* options);
+
+  // for use with default constructor ... must set or NULL pointer errors later!!
+  void SetOptions(const Options * Opt) {options_=Opt;};
 
   // Reset the contents as if the BlockBuilder was just constructed.
   void Reset();
@@ -38,6 +42,17 @@ class BlockBuilder {
   bool empty() const {
     return buffer_.empty();
   }
+
+  // retrieve current buffer, finished or not
+  Slice CurrentBuffer() {return(Slice(buffer_));};
+
+  // overwrite finished buffer, likely with compressed data
+  bool OverwriteBuffer(std::string & NewVersion)
+  {
+      if (finished_)
+          buffer_=NewVersion;
+      return(finished_);
+  }   // OverwriteBuffer
 
  private:
   const Options*        options_;

--- a/table/filter_block.cc
+++ b/table/filter_block.cc
@@ -38,8 +38,30 @@ void FilterBlockBuilder::StartBlock(uint64_t block_offset) {
 
 void FilterBlockBuilder::AddKey(const Slice& key) {
   Slice k = key;
+  std::string transform_temp;
+  Slice transform_key;
+
+  transform_key=policy_->TransformKey(key, transform_temp);
+
   start_.push_back(keys_.size());
-  keys_.append(k.data(), k.size());
+  keys_.append(transform_key.data(), transform_key.size());
+}
+
+void FilterBlockBuilder::AddKeys(
+    std::vector<size_t> & Starts,
+    std::string & Keys)
+{
+  const size_t num_keys = Starts.size();
+  size_t loop, offset, length;
+  Slice key;
+
+  start_.reserve(start_.size()+Starts.size());
+  for (loop=0, offset=0; loop<num_keys; ++loop, offset+=length)
+  {
+      const char* base = Keys.data() + offset;
+      length = Starts[loop] - offset;
+      AddKey(Slice(base, length));
+  }
 }
 
 Slice FilterBlockBuilder::Finish() {

--- a/table/filter_block.cc
+++ b/table/filter_block.cc
@@ -48,18 +48,18 @@ void FilterBlockBuilder::AddKey(const Slice& key) {
 }
 
 void FilterBlockBuilder::AddKeys(
-    std::vector<size_t> & Starts,
+    std::vector<size_t> & Lengths,
     std::string & Keys)
 {
-  const size_t num_keys = Starts.size();
+  const size_t num_keys = Lengths.size();
   size_t loop, offset, length;
   Slice key;
 
-  start_.reserve(start_.size()+Starts.size());
+  start_.reserve(start_.size()+Lengths.size());
   for (loop=0, offset=0; loop<num_keys; ++loop, offset+=length)
   {
       const char* base = Keys.data() + offset;
-      length = Starts[loop] - offset;
+      length = Lengths[loop] - offset;
       AddKey(Slice(base, length));
   }
 }

--- a/table/filter_block.cc
+++ b/table/filter_block.cc
@@ -48,14 +48,14 @@ void FilterBlockBuilder::AddKey(const Slice& key) {
 }
 
 void FilterBlockBuilder::AddKeys(
-    std::vector<size_t> & Lengths,
+    std::vector<size_t> & Starts,
     std::string & Keys)
 {
-  const size_t num_keys = Lengths.size();
+  const size_t num_keys = Starts.size();
   size_t loop, offset, length;
   Slice key;
 
-  start_.reserve(start_.size()+Lengths.size());
+  start_.reserve(start_.size()+Starts.size());
   for (loop=0, offset=0; loop<num_keys; ++loop, offset+=length)
   {
       const char* base = Keys.data() + offset;

--- a/table/filter_block.cc
+++ b/table/filter_block.cc
@@ -35,8 +35,30 @@ void FilterBlockBuilder::StartBlock(uint64_t block_offset) {
 
 void FilterBlockBuilder::AddKey(const Slice& key) {
   Slice k = key;
+  std::string transform_temp;
+  Slice transform_key;
+
+  transform_key=policy_->TransformKey(key, transform_temp);
+
   start_.push_back(keys_.size());
-  keys_.append(k.data(), k.size());
+  keys_.append(transform_key.data(), transform_key.size());
+}
+
+void FilterBlockBuilder::AddKeys(
+    std::vector<size_t> & Starts,
+    std::string & Keys)
+{
+  const size_t num_keys = Starts.size();
+  size_t loop, offset, length;
+  Slice key;
+
+  start_.reserve(start_.size()+Starts.size());
+  for (loop=0, offset=0; loop<num_keys; ++loop, offset+=length)
+  {
+      const char* base = Keys.data() + offset;
+      length = Starts[loop] - offset;
+      AddKey(Slice(base, length));
+  }
 }
 
 Slice FilterBlockBuilder::Finish() {

--- a/table/filter_block.cc
+++ b/table/filter_block.cc
@@ -48,18 +48,18 @@ void FilterBlockBuilder::AddKey(const Slice& key) {
 }
 
 void FilterBlockBuilder::AddKeys(
-    std::vector<size_t> & Lengths,
+    std::vector<size_t> & Starts,
     std::string & Keys)
 {
-  const size_t num_keys = Lengths.size();
+  const size_t num_keys = Starts.size();
   size_t loop, offset, length;
   Slice key;
 
-  start_.reserve(start_.size()+Lengths.size());
+  start_.reserve(start_.size()+Starts.size());
   for (loop=0, offset=0; loop<num_keys; ++loop, offset+=length)
   {
       const char* base = Keys.data() + offset;
-      length = Lengths[loop] - offset;
+      length = Starts[loop] - offset;
       AddKey(Slice(base, length));
   }
 }

--- a/table/filter_block.cc
+++ b/table/filter_block.cc
@@ -59,7 +59,7 @@ void FilterBlockBuilder::AddKeys(
   for (loop=0, offset=0; loop<num_keys; ++loop, offset+=length)
   {
       const char* base = Keys.data() + offset;
-      length = Lengths[loop] - offset;
+      length = Lengths[loop];
       AddKey(Slice(base, length));
   }
 }

--- a/table/filter_block.cc
+++ b/table/filter_block.cc
@@ -48,14 +48,14 @@ void FilterBlockBuilder::AddKey(const Slice& key) {
 }
 
 void FilterBlockBuilder::AddKeys(
-    std::vector<size_t> & Starts,
+    std::vector<size_t> & Lengths,
     std::string & Keys)
 {
-  const size_t num_keys = Starts.size();
+  const size_t num_keys = Lengths.size();
   size_t loop, offset, length;
   Slice key;
 
-  start_.reserve(start_.size()+Starts.size());
+  start_.reserve(start_.size()+Lengths.size());
   for (loop=0, offset=0; loop<num_keys; ++loop, offset+=length)
   {
       const char* base = Keys.data() + offset;

--- a/table/filter_block.cc
+++ b/table/filter_block.cc
@@ -36,8 +36,8 @@ void FilterBlockBuilder::StartBlock(uint64_t block_offset) {
     last_offset_=block_offset;
 }
 
-void FilterBlockBuilder::AddKey(const Slice& key) {
-  Slice k = key;
+void FilterBlockBuilder::AddKey(const Slice& key)
+{
   std::string transform_temp;
   Slice transform_key;
 

--- a/table/filter_block.cc
+++ b/table/filter_block.cc
@@ -11,6 +11,9 @@ namespace leveldb {
 
 // See doc/table_format.txt for an explanation of the filter block format.
 
+// list of available filters within code base
+const FilterPolicy * FilterInventory::ListHead(NULL);
+
 FilterBlockBuilder::FilterBlockBuilder(const FilterPolicy* policy)
     : policy_(policy), filter_base_lg_(0), filter_base_(0), last_offset_(0)
 {
@@ -45,18 +48,18 @@ void FilterBlockBuilder::AddKey(const Slice& key) {
 }
 
 void FilterBlockBuilder::AddKeys(
-    std::vector<size_t> & Starts,
+    std::vector<size_t> & Lengths,
     std::string & Keys)
 {
-  const size_t num_keys = Starts.size();
+  const size_t num_keys = Lengths.size();
   size_t loop, offset, length;
   Slice key;
 
-  start_.reserve(start_.size()+Starts.size());
+  start_.reserve(start_.size()+Lengths.size());
   for (loop=0, offset=0; loop<num_keys; ++loop, offset+=length)
   {
       const char* base = Keys.data() + offset;
-      length = Starts[loop] - offset;
+      length = Lengths[loop] - offset;
       AddKey(Slice(base, length));
   }
 }

--- a/table/filter_block.h
+++ b/table/filter_block.h
@@ -32,6 +32,7 @@ class FilterBlockBuilder {
 
   void StartBlock(uint64_t block_offset);
   void AddKey(const Slice& key);
+  void AddKeys(std::vector<size_t> & Starts, std::string & Keys);
   Slice Finish();
 
  private:

--- a/table/filter_block_test.cc
+++ b/table/filter_block_test.cc
@@ -27,6 +27,9 @@ class TestHashFilter : public FilterPolicy {
     }
   }
 
+  virtual Slice TransformKey(const Slice & Key, std::string & Buffer) const
+    {return(Key);};
+
   virtual bool KeyMayMatch(const Slice& key, const Slice& filter) const {
     uint32_t h = Hash(key.data(), key.size(), 1);
     for (int i = 0; i + 4 <= filter.size(); i += 4) {

--- a/table/table_builder.cc
+++ b/table/table_builder.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
 #include "leveldb/table_builder.h"
+#include "table/table_builder_rep.h"
 
 #include <assert.h>
 #include "leveldb/comparator.h"
@@ -17,48 +18,6 @@
 
 namespace leveldb {
 
-struct TableBuilder::Rep {
-  Options options;
-  Options index_block_options;
-  WritableFile* file;
-  uint64_t offset;
-  Status status;
-  BlockBuilder data_block;
-  BlockBuilder index_block;
-  std::string last_key;
-  int64_t num_entries;
-  bool closed;          // Either Finish() or Abandon() has been called.
-  FilterBlockBuilder* filter_block;
-
-  // We do not emit the index entry for a block until we have seen the
-  // first key for the next data block.  This allows us to use shorter
-  // keys in the index block.  For example, consider a block boundary
-  // between the keys "the quick brown fox" and "the who".  We can use
-  // "the r" as the key for the index block entry since it is >= all
-  // entries in the first block and < all entries in subsequent
-  // blocks.
-  //
-  // Invariant: r->pending_index_entry is true only if data_block is empty.
-  bool pending_index_entry;
-  BlockHandle pending_handle;  // Handle to add to index block
-
-  std::string compressed_output;
-
-  Rep(const Options& opt, WritableFile* f)
-      : options(opt),
-        index_block_options(opt),
-        file(f),
-        offset(0),
-        data_block(&options),
-        index_block(&index_block_options),
-        num_entries(0),
-        closed(false),
-        filter_block(opt.filter_policy == NULL ? NULL
-                     : new FilterBlockBuilder(opt.filter_policy)),
-        pending_index_entry(false) {
-    index_block_options.block_restart_interval = 1;
-  }
-};
 
 TableBuilder::TableBuilder(const Options& options, WritableFile* file)
     : rep_(new Rep(options, file)) {

--- a/table/table_builder.cc
+++ b/table/table_builder.cc
@@ -3,13 +3,13 @@
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
 #include "leveldb/table_builder.h"
+#include "table/table_builder_rep.h"
 
 #include <assert.h>
 #include "leveldb/comparator.h"
 #include "leveldb/env.h"
 #include "leveldb/filter_policy.h"
 #include "leveldb/options.h"
-#include "leveldb/perf_count.h"
 #include "table/block_builder.h"
 #include "table/filter_block.h"
 #include "table/format.h"
@@ -18,49 +18,6 @@
 
 namespace leveldb {
 
-struct TableBuilder::Rep {
-  Options options;
-  Options index_block_options;
-  WritableFile* file;
-  uint64_t offset;
-  Status status;
-  BlockBuilder data_block;
-  BlockBuilder index_block;
-  std::string last_key;
-  int64_t num_entries;
-  bool closed;          // Either Finish() or Abandon() has been called.
-  FilterBlockBuilder* filter_block;
-  SstCounters sst_counters;
-
-  // We do not emit the index entry for a block until we have seen the
-  // first key for the next data block.  This allows us to use shorter
-  // keys in the index block.  For example, consider a block boundary
-  // between the keys "the quick brown fox" and "the who".  We can use
-  // "the r" as the key for the index block entry since it is >= all
-  // entries in the first block and < all entries in subsequent
-  // blocks.
-  //
-  // Invariant: r->pending_index_entry is true only if data_block is empty.
-  bool pending_index_entry;
-  BlockHandle pending_handle;  // Handle to add to index block
-
-  std::string compressed_output;
-
-  Rep(const Options& opt, WritableFile* f)
-      : options(opt),
-        index_block_options(opt),
-        file(f),
-        offset(0),
-        data_block(&options),
-        index_block(&index_block_options),
-        num_entries(0),
-        closed(false),
-        filter_block(opt.filter_policy == NULL ? NULL
-                     : new FilterBlockBuilder(opt.filter_policy)),
-        pending_index_entry(false) {
-    index_block_options.block_restart_interval = 1;
-  }
-};
 
 TableBuilder::TableBuilder(const Options& options, WritableFile* file)
     : rep_(new Rep(options, file)) {

--- a/table/table_builder.cc
+++ b/table/table_builder.cc
@@ -10,7 +10,6 @@
 #include "leveldb/env.h"
 #include "leveldb/filter_policy.h"
 #include "leveldb/options.h"
-#include "leveldb/perf_count.h"
 #include "table/block_builder.h"
 #include "table/filter_block.h"
 #include "table/format.h"

--- a/table/table_builder.cc
+++ b/table/table_builder.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
 #include "leveldb/table_builder.h"
+#include "table/table_builder_rep.h"
 
 #include <assert.h>
 #include "leveldb/comparator.h"
@@ -18,49 +19,6 @@
 
 namespace leveldb {
 
-struct TableBuilder::Rep {
-  Options options;
-  Options index_block_options;
-  WritableFile* file;
-  uint64_t offset;
-  Status status;
-  BlockBuilder data_block;
-  BlockBuilder index_block;
-  std::string last_key;
-  int64_t num_entries;
-  bool closed;          // Either Finish() or Abandon() has been called.
-  FilterBlockBuilder* filter_block;
-  SstCounters sst_counters;
-
-  // We do not emit the index entry for a block until we have seen the
-  // first key for the next data block.  This allows us to use shorter
-  // keys in the index block.  For example, consider a block boundary
-  // between the keys "the quick brown fox" and "the who".  We can use
-  // "the r" as the key for the index block entry since it is >= all
-  // entries in the first block and < all entries in subsequent
-  // blocks.
-  //
-  // Invariant: r->pending_index_entry is true only if data_block is empty.
-  bool pending_index_entry;
-  BlockHandle pending_handle;  // Handle to add to index block
-
-  std::string compressed_output;
-
-  Rep(const Options& opt, WritableFile* f)
-      : options(opt),
-        index_block_options(opt),
-        file(f),
-        offset(0),
-        data_block(&options),
-        index_block(&index_block_options),
-        num_entries(0),
-        closed(false),
-        filter_block(opt.filter_policy == NULL ? NULL
-                     : new FilterBlockBuilder(opt.filter_policy)),
-        pending_index_entry(false) {
-    index_block_options.block_restart_interval = 1;
-  }
-};
 
 TableBuilder::TableBuilder(const Options& options, WritableFile* file)
     : rep_(new Rep(options, file)) {

--- a/table/table_builder2.cc
+++ b/table/table_builder2.cc
@@ -355,7 +355,11 @@ TableBuilder2::WriteBlock2(
         {
             uint64_t timer2=rep_->options.env->NowMicros();
             // push all the keys into filter
+<<<<<<< HEAD
             r->filter_block->AddKeys(state.m_FiltLengths, state.m_FiltKeys);
+=======
+            r->filter_block->AddKeys(state.m_FiltStarts, state.m_FiltKeys);
+>>>>>>> Asynchronous write buffers to improve compaction by 14 to to 19%
             r->filter_block->StartBlock(r->offset);
         }   // if
 

--- a/table/table_builder2.cc
+++ b/table/table_builder2.cc
@@ -43,6 +43,7 @@ TableBuilder2::TableBuilder2(
     }   // for
 
     m_TimerReadWait=0;
+
     return;
 
 }   // TableBuilder2::TableBuilder2
@@ -379,8 +380,6 @@ TableBuilder2::WriteBlock2(
     r->index_block.Add(state.m_LastKey, Slice(handle_encoding));
     r->sst_counters.Inc(eSstCountIndexKeys);
 
-#if 1
-// this allows multiple memcpy
     // let next block into this portion of code
     {
         port::MutexLock lock(m_CvMutex);
@@ -389,7 +388,6 @@ TableBuilder2::WriteBlock2(
         m_NextWrite=(m_NextWrite +1 ) % eTB2Buffers;
         m_CondVar.SignalAll();
     }   // mutex scope
-#endif
 
     if (r->status.ok())
     {
@@ -409,7 +407,6 @@ TableBuilder2::WriteBlock2(
         }   // if
     }   // if
 
-#if 1
     // buffer done, put back in pile
     {
         port::MutexLock lock(m_CvMutex);
@@ -417,16 +414,7 @@ TableBuilder2::WriteBlock2(
         state.reset();
         m_CondVar.SignalAll();
     }   // mutex scope
-#else
-    // buffer done, put back in pile
-    {
-        port::MutexLock lock(m_CvMutex);
 
-        state.reset();
-        m_NextWrite=(m_NextWrite +1 ) % eTB2Buffers;
-        m_CondVar.SignalAll();
-    }   // mutex scope
-#endif
 #else
 
     handle.set_offset(r->offset);
@@ -461,6 +449,7 @@ TableBuilder2::WriteBlock2(
         r->sst_counters.Inc(eSstCountIndexKeys);
     }   // if
 
+
     // buffer done, put back in pile
     {
         port::MutexLock lock(m_CvMutex);
@@ -469,6 +458,7 @@ TableBuilder2::WriteBlock2(
         m_NextWrite=(m_NextWrite +1 ) % eTB2Buffers;
         m_CondVar.SignalAll();
     }   // mutex scope
+#endif
 
 #endif
 

--- a/table/table_builder2.cc
+++ b/table/table_builder2.cc
@@ -124,7 +124,7 @@ TableBuilder2::Add(
     if (r->filter_block != NULL)
     {
         // r->filter_block->AddKey(key);
-        block_ptr->m_FiltLengths.push_back(key.size());
+        block_ptr->m_FiltStarts.push_back(block_ptr->m_FiltKeys.size());
         block_ptr->m_FiltKeys.append(key.data(), key.size());
     }   // if
 
@@ -355,7 +355,7 @@ TableBuilder2::WriteBlock2(
         {
             uint64_t timer2=rep_->options.env->NowMicros();
             // push all the keys into filter
-            r->filter_block->AddKeys(state.m_FiltLengths, state.m_FiltKeys);
+            r->filter_block->AddKeys(state.m_FiltStarts, state.m_FiltKeys);
             r->filter_block->StartBlock(r->offset);
         }   // if
 

--- a/table/table_builder2.cc
+++ b/table/table_builder2.cc
@@ -8,7 +8,10 @@
 #include "table/table_builder_rep.h"
 
 #include <assert.h>
+<<<<<<< HEAD
 #include <sstream>
+=======
+>>>>>>> Asynchronous write buffers to improve compaction by 14 to to 19%
 #include <syslog.h>
 #include "leveldb/comparator.h"
 #include "leveldb/env.h"
@@ -19,7 +22,10 @@
 #include "table/format.h"
 #include "util/coding.h"
 #include "util/crc32c.h"
+<<<<<<< HEAD
 #include "util/mapbuffer.h"
+=======
+>>>>>>> Asynchronous write buffers to improve compaction by 14 to to 19%
 
 namespace leveldb {
 
@@ -27,7 +33,11 @@ namespace leveldb {
 TableBuilder2::TableBuilder2(
     const Options& options,
     WritableFile* file)
+<<<<<<< HEAD
     : TableBuilder(options, file), m_Abort(false), m_Finish(false),
+=======
+: TableBuilder(options, file), m_Abort(false), m_Finish(false),
+>>>>>>> Asynchronous write buffers to improve compaction by 14 to to 19%
     m_CondVar(&m_CvMutex), m_NextAdd(0), m_NextWrite(0)
 {
     int loop, ret_val;
@@ -42,9 +52,12 @@ TableBuilder2::TableBuilder2(
             Log(options.info_log, "thread creation failure in TableBuilder2 (ret_val=%d)", ret_val);
     }   // for
 
+<<<<<<< HEAD
 
     m_TimerReadWait=0;
 
+=======
+>>>>>>> Asynchronous write buffers to improve compaction by 14 to to 19%
     return;
 
 }   // TableBuilder2::TableBuilder2
@@ -53,7 +66,10 @@ TableBuilder2::TableBuilder2(
 TableBuilder2::~TableBuilder2()
 {
     // ?? double check threads are joined?
+<<<<<<< HEAD
     Log(rep_->options.info_log, "m_TimerReadWait: %llu", (unsigned long long)m_TimerReadWait);
+=======
+>>>>>>> Asynchronous write buffers to improve compaction by 14 to to 19%
 
     return;
 }   // TableBuilder2::~TableBuilder2
@@ -64,16 +80,22 @@ TableBuilder2::Add(
     const Slice& key,
     const Slice& value)
 {
+<<<<<<< HEAD
     BlockNState * block_ptr;
     Rep* r = rep_;
 
 
+=======
+     BlockNState * block_ptr;
+    Rep* r = rep_;
+>>>>>>> Asynchronous write buffers to improve compaction by 14 to to 19%
     assert(!r->closed);
     if (!ok()) return;
 
     block_ptr=NULL;
 
     // quick test without lock, most common case is state is already useful
+<<<<<<< HEAD
     if (BlockNState::eBNStateLoading!=m_Blocks[m_NextAdd].m_State
         && BlockNState::eBNStateEmpty!=m_Blocks[m_NextAdd].m_State)
     {
@@ -90,6 +112,22 @@ TableBuilder2::Add(
 
         m_TimerReadWait+=r->options.env->NowMicros() - timer;
     }   // if
+=======
+    while(BlockNState::eBNStateLoading!=m_Blocks[m_NextAdd].m_State
+          && BlockNState::eBNStateEmpty!=m_Blocks[m_NextAdd].m_State)
+    {
+        int loop;
+
+        port::MutexLock lock(m_CvMutex);
+
+        // retest now that lock held
+        if (BlockNState::eBNStateLoading!=m_Blocks[m_NextAdd].m_State
+            && BlockNState::eBNStateEmpty!=m_Blocks[m_NextAdd].m_State)
+        {
+            m_CondVar.Wait();
+        }   // if
+    }   // while
+>>>>>>> Asynchronous write buffers to improve compaction by 14 to to 19%
 
     block_ptr=&m_Blocks[m_NextAdd];
 
@@ -134,16 +172,23 @@ TableBuilder2::Add(
     if (r->filter_block != NULL)
     {
         // r->filter_block->AddKey(key);
+<<<<<<< HEAD
         block_ptr->m_FiltLengths.push_back(key.size());
+=======
+        block_ptr->m_FiltStarts.push_back(block_ptr->m_FiltKeys.size());
+>>>>>>> Asynchronous write buffers to improve compaction by 14 to to 19%
         block_ptr->m_FiltKeys.append(key.data(), key.size());
     }   // if
 
     block_ptr->m_LastKey.assign(key.data(), key.size());
     r->num_entries++;
     block_ptr->m_Block.Add(key, value);
+<<<<<<< HEAD
     r->sst_counters.Inc(eSstCountKeys);
     r->sst_counters.Add(eSstCountKeySize, key.size());
     r->sst_counters.Add(eSstCountValueSize, value.size());
+=======
+>>>>>>> Asynchronous write buffers to improve compaction by 14 to to 19%
 
     // has this block reach size limit
     const size_t estimated_block_size = block_ptr->m_Block.CurrentSizeEstimate();
@@ -271,9 +316,12 @@ TableBuilder2::CompressBlock(
     Rep* r = rep_;
     Slice raw = state.m_Block.Finish();
 
+<<<<<<< HEAD
     r->sst_counters.Inc(eSstCountBlocks);
     r->sst_counters.Add(eSstCountBlockSize, raw.size());
 
+=======
+>>>>>>> Asynchronous write buffers to improve compaction by 14 to to 19%
     state.m_Type = r->options.compression;
     // TODO(postrelease): Support more compression options: zlib?
     switch (state.m_Type)
@@ -292,13 +340,19 @@ TableBuilder2::CompressBlock(
                 // Snappy not supported, or compressed less than 12.5%, so just
                 // store uncompressed form
                 state.m_Type = kNoCompression;
+<<<<<<< HEAD
                 r->sst_counters.Inc(eSstCountCompressAborted);
+=======
+>>>>>>> Asynchronous write buffers to improve compaction by 14 to to 19%
             }
             break;
         }
     }   // switch
 
+<<<<<<< HEAD
     r->sst_counters.Add(eSstCountBlockWriteSize, state.m_Block.CurrentBuffer().size());
+=======
+>>>>>>> Asynchronous write buffers to improve compaction by 14 to to 19%
 
     // calculate the crc32c for the data
     char trailer[kBlockTrailerSize];
@@ -352,6 +406,7 @@ TableBuilder2::WriteBlock2(
     BlockHandle handle;
     Rep* r = rep_;
 
+<<<<<<< HEAD
 #if 1
     size_t total_size;
     RiakBufferPtr dest_ptr;
@@ -431,6 +486,8 @@ TableBuilder2::WriteBlock2(
     }   // mutex scope
 #endif
 #else
+=======
+>>>>>>> Asynchronous write buffers to improve compaction by 14 to to 19%
     handle.set_offset(r->offset);
     handle.set_size(state.m_Block.CurrentBuffer().size());
     r->status = r->file->Append(state.m_Block.CurrentBuffer());
@@ -452,7 +509,11 @@ TableBuilder2::WriteBlock2(
         {
             uint64_t timer2=rep_->options.env->NowMicros();
             // push all the keys into filter
+<<<<<<< HEAD
             r->filter_block->AddKeys(state.m_FiltLengths, state.m_FiltKeys);
+=======
+            r->filter_block->AddKeys(state.m_FiltStarts, state.m_FiltKeys);
+>>>>>>> Asynchronous write buffers to improve compaction by 14 to to 19%
             r->filter_block->StartBlock(r->offset);
         }   // if
 
@@ -460,10 +521,15 @@ TableBuilder2::WriteBlock2(
         handle.EncodeTo(&handle_encoding);
         assert(true==state.m_KeyShortened);
         r->index_block.Add(state.m_LastKey, Slice(handle_encoding));
+<<<<<<< HEAD
         r->sst_counters.Inc(eSstCountIndexKeys);
     }   // if
 
 
+=======
+    }   // if
+
+>>>>>>> Asynchronous write buffers to improve compaction by 14 to to 19%
     // buffer done, put back in pile
     {
         port::MutexLock lock(m_CvMutex);
@@ -472,7 +538,10 @@ TableBuilder2::WriteBlock2(
         m_NextWrite=(m_NextWrite +1 ) % eTB2Buffers;
         m_CondVar.SignalAll();
     }   // mutex scope
+<<<<<<< HEAD
 #endif
+=======
+>>>>>>> Asynchronous write buffers to improve compaction by 14 to to 19%
 
     return;
 
@@ -514,10 +583,14 @@ TableBuilder2::Finish()
     m_Finish=true;
     m_CondVar.SignalAll();
     for (loop=0; loop<eTB2Threads; ++loop)
+<<<<<<< HEAD
     {
         pthread_join(m_Writers[loop], NULL);
         m_Writers[loop]=0;
     }   // for
+=======
+        pthread_join(m_Writers[loop], NULL);
+>>>>>>> Asynchronous write buffers to improve compaction by 14 to to 19%
 
     Status status=TableBuilder::Finish();
 
@@ -536,6 +609,7 @@ void TableBuilder2::Abandon() {
     // let all workers complete
     int loop;
     m_Finish=true;
+<<<<<<< HEAD
     m_Abort=true;
     {
         port::MutexLock lock(m_CvMutex);
@@ -568,4 +642,12 @@ TableBuilder2::Dump() const
 
 }   // TableBuilder2::Dump
 
+=======
+    m_CondVar.SignalAll();
+    for (loop=0; loop<eTB2Threads; ++loop)
+        pthread_join(m_Writers[loop], NULL);
+}
+
+
+>>>>>>> Asynchronous write buffers to improve compaction by 14 to to 19%
 }  // namespace leveldb

--- a/table/table_builder2.cc
+++ b/table/table_builder2.cc
@@ -131,7 +131,7 @@ TableBuilder2::Add(
     if (r->filter_block != NULL)
     {
         // r->filter_block->AddKey(key);
-        block_ptr->m_FiltStarts.push_back(block_ptr->m_FiltKeys.size());
+        block_ptr->m_FiltLengths.push_back(key.size());
         block_ptr->m_FiltKeys.append(key.data(), key.size());
     }   // if
 
@@ -450,7 +450,7 @@ TableBuilder2::WriteBlock2(
         {
             uint64_t timer2=rep_->options.env->NowMicros();
             // push all the keys into filter
-            r->filter_block->AddKeys(state.m_FiltStarts, state.m_FiltKeys);
+            r->filter_block->AddKeys(state.m_FiltLengths, state.m_FiltKeys);
             r->filter_block->StartBlock(r->offset);
         }   // if
 

--- a/table/table_builder2.cc
+++ b/table/table_builder2.cc
@@ -131,7 +131,7 @@ TableBuilder2::Add(
     if (r->filter_block != NULL)
     {
         // r->filter_block->AddKey(key);
-        block_ptr->m_FiltLengths.push_back(key.size());
+        block_ptr->m_FiltStarts.push_back(block_ptr->m_FiltKeys.size());
         block_ptr->m_FiltKeys.append(key.data(), key.size());
     }   // if
 
@@ -450,7 +450,7 @@ TableBuilder2::WriteBlock2(
         {
             uint64_t timer2=rep_->options.env->NowMicros();
             // push all the keys into filter
-            r->filter_block->AddKeys(state.m_FiltLengths, state.m_FiltKeys);
+            r->filter_block->AddKeys(state.m_FiltStarts, state.m_FiltKeys);
             r->filter_block->StartBlock(r->offset);
         }   // if
 

--- a/table/table_builder2.cc
+++ b/table/table_builder2.cc
@@ -63,6 +63,8 @@ TableBuilder2::~TableBuilder2()
 }   // TableBuilder2::~TableBuilder2
 
 
+// reminder:  only one thread calling Add(), but it interacts with background
+//            threads performing write operations
 void
 TableBuilder2::Add(
     const Slice& key,
@@ -156,7 +158,7 @@ TableBuilder2::Add(
 }
 
 
-
+// Flush() is only called by singleton read thread.
 void
 TableBuilder2::Flush()
 {
@@ -369,7 +371,7 @@ TableBuilder2::WriteBlock2(
     size_t total_size;
     RiakBufferPtr dest_ptr;
 
-#if 1
+#if 0
     if (0!=m_PriorityLevel)
     {
         bool again;
@@ -387,7 +389,6 @@ TableBuilder2::WriteBlock2(
             timeout.tv_sec+=1;
             ret_val=pthread_rwlock_timedwrlock(&gThreadLock0, &timeout);
 #else
-xx
             // ugly spin lock
             ret_val=pthread_rwlock_trywrlock(&gThreadLock0);
             if (EBUSY==ret_val)

--- a/table/table_builder2.cc
+++ b/table/table_builder2.cc
@@ -1,0 +1,442 @@
+// Copyright (c) 2011 The LevelDB Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file. See the AUTHORS file for names of contributors.
+
+// A riak addon to original TableBuilder creating parallel compression for multiple blocks
+
+#include "table/table_builder2.h"
+#include "table/table_builder_rep.h"
+
+#include <assert.h>
+#include <syslog.h>
+#include "leveldb/comparator.h"
+#include "leveldb/env.h"
+#include "leveldb/filter_policy.h"
+#include "leveldb/options.h"
+#include "table/block_builder.h"
+#include "table/filter_block.h"
+#include "table/format.h"
+#include "util/coding.h"
+#include "util/crc32c.h"
+
+namespace leveldb {
+
+
+TableBuilder2::TableBuilder2(
+    const Options& options,
+    WritableFile* file)
+: TableBuilder(options, file), m_Abort(false), m_Finish(false),
+    m_CondVar(&m_CvMutex), m_NextAdd(0), m_NextWrite(0)
+{
+    int loop, ret_val;
+
+    for (loop=0; loop<eTB2Buffers; ++loop)
+        m_Blocks[loop].m_Block.SetOptions(&rep_->options);
+
+    for (loop=0; loop<eTB2Threads; ++loop)
+    {
+        ret_val=pthread_create(&m_Writers[loop], NULL, &WorkerThreadEntry, this);
+        if (0!=ret_val)
+            Log(options.info_log, "thread creation failure in TableBuilder2 (ret_val=%d)", ret_val);
+    }   // for
+
+    return;
+
+}   // TableBuilder2::TableBuilder2
+
+
+TableBuilder2::~TableBuilder2()
+{
+    // ?? double check threads are joined?
+
+    return;
+}   // TableBuilder2::~TableBuilder2
+
+
+void
+TableBuilder2::Add(
+    const Slice& key,
+    const Slice& value)
+{
+     BlockNState * block_ptr;
+    Rep* r = rep_;
+    assert(!r->closed);
+    if (!ok()) return;
+
+    block_ptr=NULL;
+
+    // quick test without lock, most common case is state is already useful
+    while(BlockNState::eBNStateLoading!=m_Blocks[m_NextAdd].m_State
+          && BlockNState::eBNStateEmpty!=m_Blocks[m_NextAdd].m_State)
+    {
+        int loop;
+
+        port::MutexLock lock(m_CvMutex);
+
+        // retest now that lock held
+        if (BlockNState::eBNStateLoading!=m_Blocks[m_NextAdd].m_State
+            && BlockNState::eBNStateEmpty!=m_Blocks[m_NextAdd].m_State)
+        {
+            m_CondVar.Wait();
+        }   // if
+    }   // while
+
+    block_ptr=&m_Blocks[m_NextAdd];
+
+    // sanity tests
+    assert(BlockNState::eBNStateLoading==m_Blocks[m_NextAdd].m_State
+           || BlockNState::eBNStateEmpty==m_Blocks[m_NextAdd].m_State);
+
+//    if (r->num_entries > 0 )
+    if (BlockNState::eBNStateEmpty!=block_ptr->m_State)
+    {
+        assert(r->options.comparator->Compare(key, Slice(block_ptr->m_LastKey)) > 0);
+    }
+
+    // this is first key of this new block
+    // shorten key of prior block, if it exists
+    if (BlockNState::eBNStateEmpty==block_ptr->m_State)
+    {
+        {
+            port::MutexLock lock(m_CvMutex);
+            int idx;
+
+            assert(block_ptr->m_Block.empty());
+            block_ptr->m_State=BlockNState::eBNStateLoading;
+            idx= (m_NextAdd +eTB2Buffers-1) % eTB2Buffers;
+
+            if (BlockNState::eBNStateEmpty!=m_Blocks[idx].m_State)
+            {
+                r->options.comparator->FindShortestSeparator(&m_Blocks[idx].m_LastKey, key);
+                assert(false==m_Blocks[idx].m_KeyShortened);
+                m_Blocks[idx].m_KeyShortened=true;
+
+                // if block's progress is waiting for this key ... mark it ready
+                if (BlockNState::eBNStateKeyWait==m_Blocks[idx].m_State)
+                {
+                    m_Blocks[idx].m_State=BlockNState::eBNStateReady;
+                    m_CondVar.SignalAll();
+                }   // if
+            }   // if
+        }   // mutex
+    }   // if
+
+    if (r->filter_block != NULL)
+    {
+        // r->filter_block->AddKey(key);
+        block_ptr->m_FiltStarts.push_back(block_ptr->m_FiltKeys.size());
+        block_ptr->m_FiltKeys.append(key.data(), key.size());
+    }   // if
+
+    block_ptr->m_LastKey.assign(key.data(), key.size());
+    r->num_entries++;
+    block_ptr->m_Block.Add(key, value);
+
+    // has this block reach size limit
+    const size_t estimated_block_size = block_ptr->m_Block.CurrentSizeEstimate();
+    if (estimated_block_size >= r->options.block_size) {
+        Flush();
+    }   // if
+}
+
+
+
+void
+TableBuilder2::Flush()
+{
+    BlockNState * block_ptr(NULL);
+    Rep* r = rep_;
+    assert(!r->closed);
+    if (!ok()) return;
+
+    {
+        port::MutexLock lock(m_CvMutex);
+
+        block_ptr=&m_Blocks[m_NextAdd];
+        if (BlockNState::eBNStateLoading==block_ptr->m_State)
+        {
+            block_ptr->m_State=BlockNState::eBNStateFull;
+            m_NextAdd=(m_NextAdd+1) % eTB2Buffers;
+            m_CondVar.SignalAll();
+        }   // if
+
+    }   // mutex
+
+    return;
+
+}   // TableBuilder2::Flush
+
+
+void
+TableBuilder2::WorkerThread()
+{
+    bool running, all_empty;
+    int idx, loop;
+
+    running=true;
+
+    do
+    {
+
+        // look for work
+        {
+            port::MutexLock lock(m_CvMutex);
+            bool again;
+
+            // check overall status
+            for (loop=0, all_empty=true; loop<eTB2Buffers && all_empty; ++loop)
+                all_empty=m_Blocks[loop].empty();
+
+            // set state variables for this loop iteration
+            running=(!m_Abort && !(m_Finish && all_empty));
+            again=running;
+            idx=-1;
+
+            // find work if loop still running
+            if (running && !all_empty)
+            {
+                for (loop=m_NextWrite; again && loop<(m_NextWrite+eTB2Buffers); ++loop)
+                {
+                    idx=loop % eTB2Buffers;
+
+                    // ready to write?
+                    if (idx==m_NextWrite && BlockNState::eBNStateReady==m_Blocks[idx].m_State)
+                    {
+                        again=false;
+                        m_Blocks[idx].m_State=BlockNState::eBNStateWriting;
+                    }   // if
+
+                    // ready for generic work
+                    else if (BlockNState::eBNStateFull==m_Blocks[idx].m_State)
+                    {
+                        again=false;
+                        m_Blocks[idx].m_State=BlockNState::eBNStateCompress;
+                    }   // else if
+                }   // for
+            }   // if
+
+            // loop again?
+            if (again)
+            {
+                // set idx as marker of "no work found"
+                idx=-1;
+                m_CondVar.Wait();
+            }   // if
+        }   // mutex lock scope
+
+        // outside mutex
+        if (running)
+        {
+            // perform work
+            if (-1!=idx)
+            {
+                if (BlockNState::eBNStateCompress==m_Blocks[idx].m_State)
+                    CompressBlock(m_Blocks[idx]);
+//                else // eBNStateReady
+                else if (BlockNState::eBNStateWriting==m_Blocks[idx].m_State)
+                    WriteBlock2(m_Blocks[idx]);
+                else
+                    assert(false);
+            }   // if
+        }   // if
+
+    } while(running);
+
+}   // TableBuilder2::WorkerThread
+
+
+void
+TableBuilder2::CompressBlock(
+     BlockNState & state)
+{
+    assert(BlockNState::eBNStateCompress==state.m_State);
+    bool our_write(false);
+
+    uint64_t timer=rep_->options.env->NowMicros();
+
+    assert(ok());
+    Rep* r = rep_;
+    Slice raw = state.m_Block.Finish();
+
+    state.m_Type = r->options.compression;
+    // TODO(postrelease): Support more compression options: zlib?
+    switch (state.m_Type)
+    {
+        case kNoCompression:
+            // do nothing
+            break;
+
+        case kSnappyCompression: {
+            std::string compressed;
+            compressed.resize(raw.size());
+            if (port::Snappy_Compress(raw.data(), raw.size(), &compressed) &&
+                compressed.size() < raw.size() - (raw.size() / 8u)) {
+                state.m_Block.OverwriteBuffer(compressed);
+            } else {
+                // Snappy not supported, or compressed less than 12.5%, so just
+                // store uncompressed form
+                state.m_Type = kNoCompression;
+            }
+            break;
+        }
+    }   // switch
+
+
+    // calculate the crc32c for the data
+    char trailer[kBlockTrailerSize];
+    trailer[0] = state.m_Type;
+    uint32_t crc = crc32c::Value(state.m_Block.CurrentBuffer().data(),
+                                 state.m_Block.CurrentBuffer().size());
+    state.m_Crc = crc32c::Extend(crc, trailer, 1);  // Extend crc to cover block type
+
+    // update object state
+    {
+        port::MutexLock lock(m_CvMutex);
+
+        // ready for write?
+        if (state.m_KeyShortened)
+        {
+            if (&state==&m_Blocks[m_NextWrite])
+            {
+                state.m_State=BlockNState::eBNStateWriting;
+                our_write=true;
+            }   // if
+            else
+                state.m_State=BlockNState::eBNStateReady;
+        }   // if
+        else
+            state.m_State=BlockNState::eBNStateKeyWait;
+
+    }   // mutex scope
+
+    // go straight to next action if block ready
+    if (our_write && BlockNState::eBNStateWriting==state.m_State)
+        WriteBlock2(state);
+    else
+        m_CondVar.SignalAll();
+
+    return;
+
+}   // TableBuilder2::CompressBlock
+
+
+void
+TableBuilder2::WriteBlock2(
+    BlockNState & state)
+{
+    // File format contains a sequence of blocks where each block has:
+    //    block_data: uint8[n]
+    //    type: uint8
+    //    crc: uint32
+    assert(BlockNState::eBNStateWriting==state.m_State);
+    uint64_t timer=rep_->options.env->NowMicros();
+
+    BlockHandle handle;
+    Rep* r = rep_;
+
+    handle.set_offset(r->offset);
+    handle.set_size(state.m_Block.CurrentBuffer().size());
+    r->status = r->file->Append(state.m_Block.CurrentBuffer());
+    if (r->status.ok())
+    {
+        char trailer[kBlockTrailerSize];
+        trailer[0] = state.m_Type;
+        EncodeFixed32(trailer+1, crc32c::Mask(state.m_Crc));
+        r->status = r->file->Append(Slice(trailer, kBlockTrailerSize));
+        if (r->status.ok())
+        {
+            r->offset += state.m_Block.CurrentBuffer().size() + kBlockTrailerSize;
+        }   // if
+    }   // if
+
+    if (r->status.ok())
+    {
+        if (r->filter_block != NULL)
+        {
+            uint64_t timer2=rep_->options.env->NowMicros();
+            // push all the keys into filter
+            r->filter_block->AddKeys(state.m_FiltStarts, state.m_FiltKeys);
+            r->filter_block->StartBlock(r->offset);
+        }   // if
+
+        std::string handle_encoding;
+        handle.EncodeTo(&handle_encoding);
+        assert(true==state.m_KeyShortened);
+        r->index_block.Add(state.m_LastKey, Slice(handle_encoding));
+    }   // if
+
+    // buffer done, put back in pile
+    {
+        port::MutexLock lock(m_CvMutex);
+
+        state.reset();
+        m_NextWrite=(m_NextWrite +1 ) % eTB2Buffers;
+        m_CondVar.SignalAll();
+    }   // mutex scope
+
+    return;
+
+}   // TableBuilder2::WriteBlock2
+
+
+Status
+TableBuilder2::Finish()
+{
+    Rep* r = rep_;
+    int loop, idx;
+    uint64_t timer=rep_->options.env->NowMicros();
+
+    Flush();
+    assert(!r->closed);
+    // set by TableBuilder::Finish()  r->closed = true;
+
+    // encode the last key of last block added
+    idx=(m_NextAdd+eTB2Buffers-1) % eTB2Buffers;
+    {
+        port::MutexLock lock(m_CvMutex);
+
+        if (BlockNState::eBNStateEmpty!=m_Blocks[idx].m_State)
+        {
+            r->options.comparator->FindShortSuccessor(&m_Blocks[idx].m_LastKey);
+            assert(false==m_Blocks[idx].m_KeyShortened);
+            m_Blocks[idx].m_KeyShortened=true;
+
+            // if block's progress is waiting for this key ... mark it ready
+            if (BlockNState::eBNStateKeyWait==m_Blocks[idx].m_State)
+            {
+                m_Blocks[idx].m_State=BlockNState::eBNStateReady;
+                m_CondVar.SignalAll();
+            }   // if
+        }   // if
+    }   // mutex
+
+    // let all workers complete
+    m_Finish=true;
+    m_CondVar.SignalAll();
+    for (loop=0; loop<eTB2Threads; ++loop)
+        pthread_join(m_Writers[loop], NULL);
+
+    Status status=TableBuilder::Finish();
+
+    return(status);
+
+
+//    return(TableBuilder::Finish());
+
+}
+
+void TableBuilder2::Abandon() {
+  Rep* r = rep_;
+  assert(!r->closed);
+  r->closed = true;
+
+    // let all workers complete
+    int loop;
+    m_Finish=true;
+    m_CondVar.SignalAll();
+    for (loop=0; loop<eTB2Threads; ++loop)
+        pthread_join(m_Writers[loop], NULL);
+}
+
+
+}  // namespace leveldb

--- a/table/table_builder2.cc
+++ b/table/table_builder2.cc
@@ -355,11 +355,7 @@ TableBuilder2::WriteBlock2(
         {
             uint64_t timer2=rep_->options.env->NowMicros();
             // push all the keys into filter
-<<<<<<< HEAD
             r->filter_block->AddKeys(state.m_FiltLengths, state.m_FiltKeys);
-=======
-            r->filter_block->AddKeys(state.m_FiltStarts, state.m_FiltKeys);
->>>>>>> Asynchronous write buffers to improve compaction by 14 to to 19%
             r->filter_block->StartBlock(r->offset);
         }   // if
 

--- a/table/table_builder2.cc
+++ b/table/table_builder2.cc
@@ -382,6 +382,8 @@ TableBuilder2::WriteBlock2(
     r->index_block.Add(state.m_LastKey, Slice(handle_encoding));
     r->sst_counters.Inc(eSstCountIndexKeys);
 
+#if 1
+// this allows multiple memcpy
     // let next block into this portion of code
     {
         port::MutexLock lock(m_CvMutex);
@@ -390,6 +392,7 @@ TableBuilder2::WriteBlock2(
         m_NextWrite=(m_NextWrite +1 ) % eTB2Buffers;
         m_CondVar.SignalAll();
     }   // mutex scope
+#endif
 
     if (r->status.ok())
     {
@@ -409,6 +412,7 @@ TableBuilder2::WriteBlock2(
         }   // if
     }   // if
 
+#if 1
     // buffer done, put back in pile
     {
         port::MutexLock lock(m_CvMutex);
@@ -416,7 +420,16 @@ TableBuilder2::WriteBlock2(
         state.reset();
         m_CondVar.SignalAll();
     }   // mutex scope
+#else
+    // buffer done, put back in pile
+    {
+        port::MutexLock lock(m_CvMutex);
 
+        state.reset();
+        m_NextWrite=(m_NextWrite +1 ) % eTB2Buffers;
+        m_CondVar.SignalAll();
+    }   // mutex scope
+#endif
 #else
     handle.set_offset(r->offset);
     handle.set_size(state.m_Block.CurrentBuffer().size());

--- a/table/table_builder2.cc
+++ b/table/table_builder2.cc
@@ -124,7 +124,7 @@ TableBuilder2::Add(
     if (r->filter_block != NULL)
     {
         // r->filter_block->AddKey(key);
-        block_ptr->m_FiltStarts.push_back(block_ptr->m_FiltKeys.size());
+        block_ptr->m_FiltLengths.push_back(key.size());
         block_ptr->m_FiltKeys.append(key.data(), key.size());
     }   // if
 
@@ -355,7 +355,7 @@ TableBuilder2::WriteBlock2(
         {
             uint64_t timer2=rep_->options.env->NowMicros();
             // push all the keys into filter
-            r->filter_block->AddKeys(state.m_FiltStarts, state.m_FiltKeys);
+            r->filter_block->AddKeys(state.m_FiltLengths, state.m_FiltKeys);
             r->filter_block->StartBlock(r->offset);
         }   // if
 

--- a/table/table_builder2.cc
+++ b/table/table_builder2.cc
@@ -8,10 +8,7 @@
 #include "table/table_builder_rep.h"
 
 #include <assert.h>
-<<<<<<< HEAD
 #include <sstream>
-=======
->>>>>>> Asynchronous write buffers to improve compaction by 14 to to 19%
 #include <syslog.h>
 #include "leveldb/comparator.h"
 #include "leveldb/env.h"
@@ -22,10 +19,7 @@
 #include "table/format.h"
 #include "util/coding.h"
 #include "util/crc32c.h"
-<<<<<<< HEAD
 #include "util/mapbuffer.h"
-=======
->>>>>>> Asynchronous write buffers to improve compaction by 14 to to 19%
 
 namespace leveldb {
 
@@ -33,11 +27,7 @@ namespace leveldb {
 TableBuilder2::TableBuilder2(
     const Options& options,
     WritableFile* file)
-<<<<<<< HEAD
     : TableBuilder(options, file), m_Abort(false), m_Finish(false),
-=======
-: TableBuilder(options, file), m_Abort(false), m_Finish(false),
->>>>>>> Asynchronous write buffers to improve compaction by 14 to to 19%
     m_CondVar(&m_CvMutex), m_NextAdd(0), m_NextWrite(0)
 {
     int loop, ret_val;
@@ -52,12 +42,7 @@ TableBuilder2::TableBuilder2(
             Log(options.info_log, "thread creation failure in TableBuilder2 (ret_val=%d)", ret_val);
     }   // for
 
-<<<<<<< HEAD
-
     m_TimerReadWait=0;
-
-=======
->>>>>>> Asynchronous write buffers to improve compaction by 14 to to 19%
     return;
 
 }   // TableBuilder2::TableBuilder2
@@ -66,10 +51,7 @@ TableBuilder2::TableBuilder2(
 TableBuilder2::~TableBuilder2()
 {
     // ?? double check threads are joined?
-<<<<<<< HEAD
     Log(rep_->options.info_log, "m_TimerReadWait: %llu", (unsigned long long)m_TimerReadWait);
-=======
->>>>>>> Asynchronous write buffers to improve compaction by 14 to to 19%
 
     return;
 }   // TableBuilder2::~TableBuilder2
@@ -80,22 +62,15 @@ TableBuilder2::Add(
     const Slice& key,
     const Slice& value)
 {
-<<<<<<< HEAD
     BlockNState * block_ptr;
     Rep* r = rep_;
 
-
-=======
-     BlockNState * block_ptr;
-    Rep* r = rep_;
->>>>>>> Asynchronous write buffers to improve compaction by 14 to to 19%
     assert(!r->closed);
     if (!ok()) return;
 
     block_ptr=NULL;
 
     // quick test without lock, most common case is state is already useful
-<<<<<<< HEAD
     if (BlockNState::eBNStateLoading!=m_Blocks[m_NextAdd].m_State
         && BlockNState::eBNStateEmpty!=m_Blocks[m_NextAdd].m_State)
     {
@@ -112,22 +87,6 @@ TableBuilder2::Add(
 
         m_TimerReadWait+=r->options.env->NowMicros() - timer;
     }   // if
-=======
-    while(BlockNState::eBNStateLoading!=m_Blocks[m_NextAdd].m_State
-          && BlockNState::eBNStateEmpty!=m_Blocks[m_NextAdd].m_State)
-    {
-        int loop;
-
-        port::MutexLock lock(m_CvMutex);
-
-        // retest now that lock held
-        if (BlockNState::eBNStateLoading!=m_Blocks[m_NextAdd].m_State
-            && BlockNState::eBNStateEmpty!=m_Blocks[m_NextAdd].m_State)
-        {
-            m_CondVar.Wait();
-        }   // if
-    }   // while
->>>>>>> Asynchronous write buffers to improve compaction by 14 to to 19%
 
     block_ptr=&m_Blocks[m_NextAdd];
 
@@ -172,23 +131,16 @@ TableBuilder2::Add(
     if (r->filter_block != NULL)
     {
         // r->filter_block->AddKey(key);
-<<<<<<< HEAD
         block_ptr->m_FiltLengths.push_back(key.size());
-=======
-        block_ptr->m_FiltStarts.push_back(block_ptr->m_FiltKeys.size());
->>>>>>> Asynchronous write buffers to improve compaction by 14 to to 19%
         block_ptr->m_FiltKeys.append(key.data(), key.size());
     }   // if
 
     block_ptr->m_LastKey.assign(key.data(), key.size());
     r->num_entries++;
     block_ptr->m_Block.Add(key, value);
-<<<<<<< HEAD
     r->sst_counters.Inc(eSstCountKeys);
     r->sst_counters.Add(eSstCountKeySize, key.size());
     r->sst_counters.Add(eSstCountValueSize, value.size());
-=======
->>>>>>> Asynchronous write buffers to improve compaction by 14 to to 19%
 
     // has this block reach size limit
     const size_t estimated_block_size = block_ptr->m_Block.CurrentSizeEstimate();
@@ -316,12 +268,9 @@ TableBuilder2::CompressBlock(
     Rep* r = rep_;
     Slice raw = state.m_Block.Finish();
 
-<<<<<<< HEAD
     r->sst_counters.Inc(eSstCountBlocks);
     r->sst_counters.Add(eSstCountBlockSize, raw.size());
 
-=======
->>>>>>> Asynchronous write buffers to improve compaction by 14 to to 19%
     state.m_Type = r->options.compression;
     // TODO(postrelease): Support more compression options: zlib?
     switch (state.m_Type)
@@ -340,19 +289,13 @@ TableBuilder2::CompressBlock(
                 // Snappy not supported, or compressed less than 12.5%, so just
                 // store uncompressed form
                 state.m_Type = kNoCompression;
-<<<<<<< HEAD
                 r->sst_counters.Inc(eSstCountCompressAborted);
-=======
->>>>>>> Asynchronous write buffers to improve compaction by 14 to to 19%
             }
             break;
         }
     }   // switch
 
-<<<<<<< HEAD
     r->sst_counters.Add(eSstCountBlockWriteSize, state.m_Block.CurrentBuffer().size());
-=======
->>>>>>> Asynchronous write buffers to improve compaction by 14 to to 19%
 
     // calculate the crc32c for the data
     char trailer[kBlockTrailerSize];
@@ -406,7 +349,6 @@ TableBuilder2::WriteBlock2(
     BlockHandle handle;
     Rep* r = rep_;
 
-<<<<<<< HEAD
 #if 1
     size_t total_size;
     RiakBufferPtr dest_ptr;
@@ -486,8 +428,7 @@ TableBuilder2::WriteBlock2(
     }   // mutex scope
 #endif
 #else
-=======
->>>>>>> Asynchronous write buffers to improve compaction by 14 to to 19%
+
     handle.set_offset(r->offset);
     handle.set_size(state.m_Block.CurrentBuffer().size());
     r->status = r->file->Append(state.m_Block.CurrentBuffer());
@@ -509,11 +450,7 @@ TableBuilder2::WriteBlock2(
         {
             uint64_t timer2=rep_->options.env->NowMicros();
             // push all the keys into filter
-<<<<<<< HEAD
             r->filter_block->AddKeys(state.m_FiltLengths, state.m_FiltKeys);
-=======
-            r->filter_block->AddKeys(state.m_FiltStarts, state.m_FiltKeys);
->>>>>>> Asynchronous write buffers to improve compaction by 14 to to 19%
             r->filter_block->StartBlock(r->offset);
         }   // if
 
@@ -521,15 +458,9 @@ TableBuilder2::WriteBlock2(
         handle.EncodeTo(&handle_encoding);
         assert(true==state.m_KeyShortened);
         r->index_block.Add(state.m_LastKey, Slice(handle_encoding));
-<<<<<<< HEAD
         r->sst_counters.Inc(eSstCountIndexKeys);
     }   // if
 
-
-=======
-    }   // if
-
->>>>>>> Asynchronous write buffers to improve compaction by 14 to to 19%
     // buffer done, put back in pile
     {
         port::MutexLock lock(m_CvMutex);
@@ -538,10 +469,8 @@ TableBuilder2::WriteBlock2(
         m_NextWrite=(m_NextWrite +1 ) % eTB2Buffers;
         m_CondVar.SignalAll();
     }   // mutex scope
-<<<<<<< HEAD
+
 #endif
-=======
->>>>>>> Asynchronous write buffers to improve compaction by 14 to to 19%
 
     return;
 
@@ -583,14 +512,10 @@ TableBuilder2::Finish()
     m_Finish=true;
     m_CondVar.SignalAll();
     for (loop=0; loop<eTB2Threads; ++loop)
-<<<<<<< HEAD
     {
         pthread_join(m_Writers[loop], NULL);
         m_Writers[loop]=0;
     }   // for
-=======
-        pthread_join(m_Writers[loop], NULL);
->>>>>>> Asynchronous write buffers to improve compaction by 14 to to 19%
 
     Status status=TableBuilder::Finish();
 
@@ -609,7 +534,6 @@ void TableBuilder2::Abandon() {
     // let all workers complete
     int loop;
     m_Finish=true;
-<<<<<<< HEAD
     m_Abort=true;
     {
         port::MutexLock lock(m_CvMutex);
@@ -642,12 +566,4 @@ TableBuilder2::Dump() const
 
 }   // TableBuilder2::Dump
 
-=======
-    m_CondVar.SignalAll();
-    for (loop=0; loop<eTB2Threads; ++loop)
-        pthread_join(m_Writers[loop], NULL);
-}
-
-
->>>>>>> Asynchronous write buffers to improve compaction by 14 to to 19%
 }  // namespace leveldb

--- a/table/table_builder2.h
+++ b/table/table_builder2.h
@@ -36,7 +36,7 @@ private:
 
 
 public:
-    TableBuilder2(const Options& options, WritableFile* file);
+    TableBuilder2(const Options& options, WritableFile* file, int PriorityLevel);
 
     // REQUIRES: Either Finish() or Abandon() has been called.
     virtual ~TableBuilder2();
@@ -117,6 +117,7 @@ protected:
     BlockNState m_Blocks[eTB2Buffers];
     volatile unsigned m_NextAdd;                          //!< m_Block for Add, changed only by Add thread(s)
     volatile unsigned m_NextWrite;
+    int m_PriorityLevel;                          //!< level of output file builder2 is creating
 
     volatile uint64_t m_TimerReadWait;
 

--- a/table/table_builder2.h
+++ b/table/table_builder2.h
@@ -85,7 +85,7 @@ protected:
         volatile bool m_KeyShortened;     //!< true when first key of next block seen and applied
         uint32_t m_Crc;                   //!< crc after potential compression
         std::string m_FiltKeys;           //!< keys to put into filter
-        std::vector<size_t> m_FiltStarts; //!< size of each key dumped into m_FiltKeys
+        std::vector<size_t> m_FiltLengths; //!< size of each key dumped into m_FiltKeys
 
         BlockNState()
         : m_State(eBNStateEmpty), m_Type(kNoCompression), m_KeyShortened(false), m_Crc(0) {reset();};
@@ -99,7 +99,7 @@ protected:
             m_KeyShortened=false;
             m_Crc=0;
             m_FiltKeys.clear();
-            m_FiltStarts.clear();
+            m_FiltLengths.clear();
         }   // reset
 
         bool empty() const {return(eBNStateEmpty==m_State);}

--- a/table/table_builder2.h
+++ b/table/table_builder2.h
@@ -1,0 +1,138 @@
+// Copyright (c) 2011 The LevelDB Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file. See the AUTHORS file for names of contributors.
+//
+// TableBuilder provides the interface used to build a Table
+// (an immutable and sorted map from keys to values).
+//
+// Multiple threads can invoke const methods on a TableBuilder without
+// external synchronization, but if any of the threads may call a
+// non-const method, all threads accessing the same TableBuilder must use
+// external synchronization.
+
+// A riak addon to original TableBuilder creating parallel compression for multiple blocks
+
+#ifndef STORAGE_LEVELDB_INCLUDE_TABLE_BUILDER2_H_
+#define STORAGE_LEVELDB_INCLUDE_TABLE_BUILDER2_H_
+
+#include "leveldb/table_builder.h"
+
+#include "port/port.h"
+#include "table/block_builder.h"
+
+namespace leveldb {
+
+class BlockBuilder;
+class BlockHandle;
+class WritableFile;
+
+class TableBuilder2 :public TableBuilder {
+private:
+    enum
+    {
+        eTB2Threads=4,    //!< number of compression threads
+        eTB2Buffers=6,    //!< number of shared block buffers
+    };
+
+
+public:
+    TableBuilder2(const Options& options, WritableFile* file);
+
+    // REQUIRES: Either Finish() or Abandon() has been called.
+    virtual ~TableBuilder2();
+
+    // Add key,value to the table being constructed.
+    // REQUIRES: key is after any previously added key according to comparator.
+    // REQUIRES: Finish(), Abandon() have not been called
+    virtual void Add(const Slice& key, const Slice& value);
+
+    // Advanced operation: flush any buffered key/value pairs to file.
+    // Can be used to ensure that two adjacent entries never live in
+    // the same data block.  Most clients should not need to use this method.
+    // REQUIRES: Finish(), Abandon() have not been called
+    virtual void Flush();
+
+    // Finish building the table.  Stops using the file passed to the
+    // constructor after this function returns.
+    // REQUIRES: Finish(), Abandon() have not been called
+    virtual Status Finish();
+
+    // Indicate that the contents of this builder should be abandoned.  Stops
+    // using the file passed to the constructor after this function returns.
+    // If the caller is not going to call Finish(), it must call Abandon()
+    // before destroying this builder.
+    // REQUIRES: Finish(), Abandon() have not been called
+    virtual void Abandon();
+
+protected:
+    struct BlockNState
+    {
+        enum BNState
+        {
+            eBNStateEmpty=0,    //!< BlockNState object unused
+            eBNStateLoading=1,  //!< BlockNState object contains some data
+            eBNStateFull=2,     //!< BlockNState object has data, needs compression
+            eBNStateCompress=3, //!< BlockNState object in process of compressing
+            eBNStateKeyWait=4,  //!< compression complete, but no "next key"
+            eBNStateReady=5,    //!< ready for write, but not first on list
+            eBNStateWriting=6,  //!< write in progress now
+        };
+
+        volatile BNState m_State;
+        CompressionType m_Type;           //!< block type:  compressed or not
+        BlockBuilder m_Block;
+        std::string m_LastKey;            //!< last key written to block, shortened if m_KeyShortened true
+        volatile bool m_KeyShortened;     //!< true when first key of next block seen and applied
+        uint32_t m_Crc;                   //!< crc after potential compression
+        std::string m_FiltKeys;           //!< keys to put into filter
+        std::vector<size_t> m_FiltStarts; //!< size of each key dumped into m_FiltKeys
+
+        BlockNState()
+        : m_State(eBNStateEmpty), m_Type(kNoCompression), m_KeyShortened(false), m_Crc(0) {reset();};
+
+        void reset()
+        {
+            m_State=eBNStateEmpty;
+            m_Type=kNoCompression;
+            m_Block.Reset();
+            m_LastKey.clear();
+            m_KeyShortened=false;
+            m_Crc=0;
+            m_FiltKeys.clear();
+            m_FiltStarts.clear();
+        }   // reset
+
+        bool empty() const {return(eBNStateEmpty==m_State);}
+    };
+
+    volatile bool m_Abort;                        //!< indicate when work should just stop, incomplete
+    volatile bool m_Finish;                       //!< indicate no more inbound keys, finish and exit
+    port::Mutex m_CvMutex;                        //!< mutex tied to condition variable
+    port::CondVar m_CondVar;                      //!<
+    pthread_t m_Writers[eTB2Threads];
+    BlockNState m_Blocks[eTB2Buffers];
+    volatile unsigned m_NextAdd;                          //!< m_Block for Add, changed only by Add thread(s)
+    volatile unsigned m_NextWrite;
+
+    // WorkerThreadEntry calls here with C++ object established
+    void WorkerThread();
+
+    // pthread_create entry point, C type function
+    static void* WorkerThreadEntry(void* arg)
+    {
+        reinterpret_cast<TableBuilder2 *>(arg)->WorkerThread();
+        return NULL;
+    };
+
+    void CompressBlock(BlockNState & State);
+    void WriteBlock2(BlockNState & State);
+
+private:
+    // No copying allowed
+    TableBuilder2(const TableBuilder2&);
+    void operator=(const TableBuilder2&);
+};  // struct TableBuilder2
+
+}  // namespace leveldb
+
+#endif  // STORAGE_LEVELDB_INCLUDE_TABLE_BUILDER2_H_

--- a/table/table_builder2.h
+++ b/table/table_builder2.h
@@ -85,7 +85,7 @@ protected:
         volatile bool m_KeyShortened;     //!< true when first key of next block seen and applied
         uint32_t m_Crc;                   //!< crc after potential compression
         std::string m_FiltKeys;           //!< keys to put into filter
-        std::vector<size_t> m_FiltLengths; //!< size of each key dumped into m_FiltKeys
+        std::vector<size_t> m_FiltStarts; //!< size of each key dumped into m_FiltKeys
 
         BlockNState()
         : m_State(eBNStateEmpty), m_Type(kNoCompression), m_KeyShortened(false), m_Crc(0) {reset();};
@@ -99,7 +99,7 @@ protected:
             m_KeyShortened=false;
             m_Crc=0;
             m_FiltKeys.clear();
-            m_FiltLengths.clear();
+            m_FiltStarts.clear();
         }   // reset
 
         bool empty() const {return(eBNStateEmpty==m_State);}

--- a/table/table_builder2.h
+++ b/table/table_builder2.h
@@ -89,7 +89,7 @@ protected:
         volatile bool m_KeyShortened;     //!< true when first key of next block seen and applied
         uint32_t m_Crc;                   //!< crc after potential compression
         std::string m_FiltKeys;           //!< keys to put into filter
-        std::vector<size_t> m_FiltLengths; //!< size of each key dumped into m_FiltKeys
+        std::vector<size_t> m_FiltStarts; //!< size of each key dumped into m_FiltKeys
 
         BlockNState()
         : m_State(eBNStateEmpty), m_Type(kNoCompression), m_KeyShortened(false), m_Crc(0) {reset();};
@@ -103,7 +103,7 @@ protected:
             m_KeyShortened=false;
             m_Crc=0;
             m_FiltKeys.clear();
-            m_FiltLengths.clear();
+            m_FiltStarts.clear();
         }   // reset
 
         bool empty() const {return(eBNStateEmpty==m_State);}

--- a/table/table_builder2.h
+++ b/table/table_builder2.h
@@ -31,7 +31,7 @@ private:
     enum
     {
         eTB2Threads=4,    //!< number of compression threads
-        eTB2Buffers=12,   //!< number of shared block buffers
+        eTB2Buffers=256,   //!< number of shared block buffers (was 12)
     };
 
 

--- a/table/table_builder2.h
+++ b/table/table_builder2.h
@@ -31,7 +31,7 @@ private:
     enum
     {
         eTB2Threads=4,    //!< number of compression threads
-        eTB2Buffers=6,    //!< number of shared block buffers
+        eTB2Buffers=12,   //!< number of shared block buffers
     };
 
 
@@ -64,6 +64,9 @@ public:
     // REQUIRES: Finish(), Abandon() have not been called
     virtual void Abandon();
 
+    // debug tool
+    void Dump() const;
+
 protected:
     struct BlockNState
     {
@@ -76,6 +79,7 @@ protected:
             eBNStateKeyWait=4,  //!< compression complete, but no "next key"
             eBNStateReady=5,    //!< ready for write, but not first on list
             eBNStateWriting=6,  //!< write in progress now
+            eBNStateCopying=7   //!< write position known, copying data into map
         };
 
         volatile BNState m_State;
@@ -114,6 +118,8 @@ protected:
     volatile unsigned m_NextAdd;                          //!< m_Block for Add, changed only by Add thread(s)
     volatile unsigned m_NextWrite;
 
+    volatile uint64_t m_TimerReadWait;
+
     // WorkerThreadEntry calls here with C++ object established
     void WorkerThread();
 
@@ -124,6 +130,7 @@ protected:
         return NULL;
     };
 
+public:  // temporarily public to allow perf annotate to comment
     void CompressBlock(BlockNState & State);
     void WriteBlock2(BlockNState & State);
 

--- a/table/table_builder2.h
+++ b/table/table_builder2.h
@@ -89,7 +89,7 @@ protected:
         volatile bool m_KeyShortened;     //!< true when first key of next block seen and applied
         uint32_t m_Crc;                   //!< crc after potential compression
         std::string m_FiltKeys;           //!< keys to put into filter
-        std::vector<size_t> m_FiltStarts; //!< size of each key dumped into m_FiltKeys
+        std::vector<size_t> m_FiltLengths; //!< size of each key dumped into m_FiltKeys
 
         BlockNState()
         : m_State(eBNStateEmpty), m_Type(kNoCompression), m_KeyShortened(false), m_Crc(0) {reset();};
@@ -103,7 +103,7 @@ protected:
             m_KeyShortened=false;
             m_Crc=0;
             m_FiltKeys.clear();
-            m_FiltStarts.clear();
+            m_FiltLengths.clear();
         }   // reset
 
         bool empty() const {return(eBNStateEmpty==m_State);}

--- a/table/table_builder_rep.h
+++ b/table/table_builder_rep.h
@@ -9,6 +9,7 @@
 #include "leveldb/env.h"
 #include "leveldb/filter_policy.h"
 #include "leveldb/options.h"
+#include "leveldb/perf_count.h"
 #include "table/block_builder.h"
 #include "table/filter_block.h"
 #include "table/format.h"
@@ -29,6 +30,7 @@ struct TableBuilder::Rep {
   int64_t num_entries;
   bool closed;          // Either Finish() or Abandon() has been called.
   FilterBlockBuilder* filter_block;
+  SstCounters sst_counters;
 
   // We do not emit the index entry for a block until we have seen the
   // first key for the next data block.  This allows us to use shorter

--- a/table/table_builder_rep.h
+++ b/table/table_builder_rep.h
@@ -9,6 +9,7 @@
 #include "leveldb/env.h"
 #include "leveldb/filter_policy.h"
 #include "leveldb/options.h"
+#include "leveldb/perf_count.h"
 #include "table/block_builder.h"
 #include "table/filter_block.h"
 #include "table/format.h"

--- a/table/table_builder_rep.h
+++ b/table/table_builder_rep.h
@@ -1,0 +1,64 @@
+// Copyright (c) 2011 The LevelDB Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file. See the AUTHORS file for names of contributors.
+
+#include "leveldb/table_builder.h"
+
+#include <assert.h>
+#include "leveldb/comparator.h"
+#include "leveldb/env.h"
+#include "leveldb/filter_policy.h"
+#include "leveldb/options.h"
+#include "table/block_builder.h"
+#include "table/filter_block.h"
+#include "table/format.h"
+#include "util/coding.h"
+#include "util/crc32c.h"
+
+namespace leveldb {
+
+struct TableBuilder::Rep {
+  Options options;
+  Options index_block_options;
+  WritableFile* file;
+  uint64_t offset;
+  Status status;
+  BlockBuilder data_block;
+  BlockBuilder index_block;
+  std::string last_key;
+  int64_t num_entries;
+  bool closed;          // Either Finish() or Abandon() has been called.
+  FilterBlockBuilder* filter_block;
+  SstCounters sst_counters;
+
+  // We do not emit the index entry for a block until we have seen the
+  // first key for the next data block.  This allows us to use shorter
+  // keys in the index block.  For example, consider a block boundary
+  // between the keys "the quick brown fox" and "the who".  We can use
+  // "the r" as the key for the index block entry since it is >= all
+  // entries in the first block and < all entries in subsequent
+  // blocks.
+  //
+  // Invariant: r->pending_index_entry is true only if data_block is empty.
+  bool pending_index_entry;
+  BlockHandle pending_handle;  // Handle to add to index block
+
+  std::string compressed_output;
+
+  Rep(const Options& opt, WritableFile* f)
+      : options(opt),
+        index_block_options(opt),
+        file(f),
+        offset(0),
+        data_block(&options),
+        index_block(&index_block_options),
+        num_entries(0),
+        closed(false),
+        filter_block(opt.filter_policy == NULL ? NULL
+                     : new FilterBlockBuilder(opt.filter_policy)),
+        pending_index_entry(false) {
+    index_block_options.block_restart_interval = 1;
+  }
+};
+
+}  // namespace leveldb

--- a/table/table_builder_rep.h
+++ b/table/table_builder_rep.h
@@ -1,0 +1,63 @@
+// Copyright (c) 2011 The LevelDB Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file. See the AUTHORS file for names of contributors.
+
+#include "leveldb/table_builder.h"
+
+#include <assert.h>
+#include "leveldb/comparator.h"
+#include "leveldb/env.h"
+#include "leveldb/filter_policy.h"
+#include "leveldb/options.h"
+#include "table/block_builder.h"
+#include "table/filter_block.h"
+#include "table/format.h"
+#include "util/coding.h"
+#include "util/crc32c.h"
+
+namespace leveldb {
+
+struct TableBuilder::Rep {
+  Options options;
+  Options index_block_options;
+  WritableFile* file;
+  uint64_t offset;
+  Status status;
+  BlockBuilder data_block;
+  BlockBuilder index_block;
+  std::string last_key;
+  int64_t num_entries;
+  bool closed;          // Either Finish() or Abandon() has been called.
+  FilterBlockBuilder* filter_block;
+
+  // We do not emit the index entry for a block until we have seen the
+  // first key for the next data block.  This allows us to use shorter
+  // keys in the index block.  For example, consider a block boundary
+  // between the keys "the quick brown fox" and "the who".  We can use
+  // "the r" as the key for the index block entry since it is >= all
+  // entries in the first block and < all entries in subsequent
+  // blocks.
+  //
+  // Invariant: r->pending_index_entry is true only if data_block is empty.
+  bool pending_index_entry;
+  BlockHandle pending_handle;  // Handle to add to index block
+
+  std::string compressed_output;
+
+  Rep(const Options& opt, WritableFile* f)
+      : options(opt),
+        index_block_options(opt),
+        file(f),
+        offset(0),
+        data_block(&options),
+        index_block(&index_block_options),
+        num_entries(0),
+        closed(false),
+        filter_block(opt.filter_policy == NULL ? NULL
+                     : new FilterBlockBuilder(opt.filter_policy)),
+        pending_index_entry(false) {
+    index_block_options.block_restart_interval = 1;
+  }
+};
+
+}  // namespace leveldb

--- a/tools/bloom_scan.cc
+++ b/tools/bloom_scan.cc
@@ -1,0 +1,162 @@
+#include <stdlib.h>
+#include <libgen.h>
+
+#include "db/filename.h"
+#include "leveldb/env.h"
+#include "leveldb/db.h"
+#include "leveldb/cache.h"
+#include "leveldb/iterator.h"
+#include "leveldb/filter_policy.h"
+#include "leveldb/slice.h"
+#include "db/table_cache.h"
+#include "db/version_edit.h"
+#include "table/format.h"
+#include "table/block.h"
+#include "table/filter_block.h"
+
+//#include "util/logging.h"
+//#include "db/log_reader.h"
+
+void command_help();
+
+int
+main(
+    int argc,
+    char ** argv)
+{
+    bool error_seen, all_keys, csv_header, running, no_csv;
+    int counter, error_counter;
+    char ** cursor;
+
+    running=true;
+    error_seen=false;
+
+    csv_header=false;
+    all_keys=false;
+    no_csv=false;
+    counter=0;
+    error_counter=0;
+
+
+    for (cursor=argv+1; NULL!=*cursor && running; ++cursor)
+    {
+        // option flag?
+        if ('-'==**cursor)
+        {
+            char flag;
+
+            flag=*((*cursor)+1);
+            switch(flag)
+            {
+                case 'h':  csv_header=true; break;
+                case 'k':  all_keys=true; break;
+                case 'n':  no_csv=true; break;
+                default:
+                    fprintf(stderr, " option \'%c\' is not valid\n", flag);
+                    command_help();
+                    running=false;
+                    error_counter=1;
+                    error_seen=true;
+                    break;
+            }   // switch
+        }   // if
+
+        // database path
+        else
+        {
+            leveldb::DB * db_ptr;
+            leveldb::Options options;
+            leveldb::ReadOptions read_options;
+            std::string dbname;
+            leveldb::Env * env;
+            leveldb::Status status;
+            size_t get_errors, key_count;
+
+            get_errors=0;
+            key_count=0;
+            env=leveldb::Env::Default();
+
+            dbname=*cursor;
+            options.filter_policy=leveldb::NewBloomFilterPolicy2(16);
+            options.env=env;
+            options.max_open_files=250;
+            
+            read_options.verify_checksums=true;
+            read_options.fill_cache=false;     // force bloom to be used
+
+            db_ptr=NULL;
+            status=leveldb::DB::Open(options, dbname, &db_ptr);
+
+            if (status.ok())
+            {
+                leveldb::Iterator * it;
+                std::string value;
+
+                it=NULL;
+                it=db_ptr->NewIterator(read_options);
+                for (it->SeekToFirst(); it->status().ok() && it->Valid(); it->Next())
+                {
+                    ++key_count;
+
+                    if (all_keys)
+                    {
+                        leveldb::ParsedInternalKey parsed;
+                        leveldb::Slice key = it->key();
+
+                        ParseInternalKey(key, &parsed);
+                        printf("%s db %s\n", parsed.DebugStringHex().c_str(), dbname.c_str());
+                    }   // if
+
+                    status=db_ptr->Get(read_options, it->key(), &value);
+                    if (!status.ok())
+                        ++get_errors;
+                }   // for
+
+                if (!no_csv)
+                {
+                    if (csv_header)
+                    {
+                        csv_header=false;
+                        printf("database, key count, GET errors\n");
+                    }   // if
+
+                    printf("%s, %zd, %zd\n",
+                           dbname.c_str(), key_count, get_errors);
+                }   // if
+
+                delete it;
+                delete db_ptr;
+            }   // if
+            else
+            {
+                fprintf(stderr, "%s:  leveldb::Open() failed (%s)", 
+                        dbname.c_str(), status.ToString().c_str());
+                error_seen=true;
+                error_counter+=1;
+            }   // else
+        }   // else
+    }   // for
+
+    if (1==argc)
+        command_help();
+
+    return( error_seen && 0!=error_counter ? 1 : 0 );
+
+}   // main
+
+
+void
+command_help()
+{
+    fprintf(stderr, "bloom_scan [option | data_base]*\n");
+    fprintf(stderr, "  options\n");
+    fprintf(stderr, "      -h  print csv formatted header line (once)\n");
+    fprintf(stderr, "      -k  print all keys\n");
+    fprintf(stderr, "      -n  NO csv data (or header)\n");
+}   // command_help
+
+namespace leveldb {
+
+
+}  // namespace leveldb
+

--- a/tools/bloom_scan.cc
+++ b/tools/bloom_scan.cc
@@ -81,12 +81,12 @@ main(
             options.filter_policy=leveldb::NewBloomFilterPolicy2(16);
             options.env=env;
             options.max_open_files=250;
-
             read_options.verify_checksums=true;
             read_options.fill_cache=false;     // force bloom to be used
 
             db_ptr=NULL;
             timer=env->NowMicros();
+
             status=leveldb::DB::Open(options, dbname, &db_ptr);
 
             if (status.ok())

--- a/tools/bloom_scan.cc
+++ b/tools/bloom_scan.cc
@@ -81,6 +81,7 @@ main(
             options.filter_policy=leveldb::NewBloomFilterPolicy2(16);
             options.env=env;
             options.max_open_files=250;
+
             read_options.verify_checksums=true;
             read_options.fill_cache=false;     // force bloom to be used
 

--- a/util/bloom.cc
+++ b/util/bloom.cc
@@ -62,6 +62,7 @@ class BloomFilterPolicy : public FilterPolicy {
       // Use double-hashing to generate a sequence of hash values.
       // See analysis in [Kirsch,Mitzenmacher 2006].
       uint32_t h = *(uint32_t *)keys[i].data();
+
       const uint32_t delta = (h >> 17) | (h << 15);  // Rotate right 17 bits
       for (size_t j = 0; j < k_; j++) {
         const uint32_t bitpos = h % bits;

--- a/util/bloom.cc
+++ b/util/bloom.cc
@@ -34,6 +34,15 @@ class BloomFilterPolicy : public FilterPolicy {
     return "leveldb.BuiltinBloomFilter";
   }
 
+  virtual Slice TransformKey(const Slice & Key, std::string & Buffer) const
+  {
+      uint32_t hash;
+
+      hash=BloomHash(ExtractUserKey(Key));
+      Buffer.assign((char *)&hash, sizeof(hash));
+      return(Slice(Buffer));
+  };
+
   virtual void CreateFilter(const Slice* keys, int n, std::string* dst) const {
     // Compute bloom filter size (in both bits and bytes)
     size_t bits = n * bits_per_key_;
@@ -52,7 +61,11 @@ class BloomFilterPolicy : public FilterPolicy {
     for (size_t i = 0; i < n; i++) {
       // Use double-hashing to generate a sequence of hash values.
       // See analysis in [Kirsch,Mitzenmacher 2006].
+#if 0
       uint32_t h = BloomHash(keys[i]);
+#else
+      uint32_t h = *(uint32_t *)keys[i].data();
+#endif
       const uint32_t delta = (h >> 17) | (h << 15);  // Rotate right 17 bits
       for (size_t j = 0; j < k_; j++) {
         const uint32_t bitpos = h % bits;

--- a/util/bloom.cc
+++ b/util/bloom.cc
@@ -61,11 +61,7 @@ class BloomFilterPolicy : public FilterPolicy {
     for (size_t i = 0; i < n; i++) {
       // Use double-hashing to generate a sequence of hash values.
       // See analysis in [Kirsch,Mitzenmacher 2006].
-#if 0
-      uint32_t h = BloomHash(keys[i]);
-#else
       uint32_t h = *(uint32_t *)keys[i].data();
-#endif
       const uint32_t delta = (h >> 17) | (h << 15);  // Rotate right 17 bits
       for (size_t j = 0; j < k_; j++) {
         const uint32_t bitpos = h % bits;

--- a/util/bloom.cc
+++ b/util/bloom.cc
@@ -4,6 +4,7 @@
 
 #include "leveldb/filter_policy.h"
 
+#include "db/dbformat.h"
 #include "leveldb/slice.h"
 #include "util/hash.h"
 
@@ -32,6 +33,15 @@ class BloomFilterPolicy : public FilterPolicy {
     return "leveldb.BuiltinBloomFilter";
   }
 
+  virtual Slice TransformKey(const Slice & Key, std::string & Buffer) const
+  {
+      uint32_t hash;
+
+      hash=BloomHash(ExtractUserKey(Key));
+      Buffer.assign((char *)&hash, sizeof(hash));
+      return(Slice(Buffer));
+  };
+
   virtual void CreateFilter(const Slice* keys, int n, std::string* dst) const {
     // Compute bloom filter size (in both bits and bytes)
     size_t bits = n * bits_per_key_;
@@ -50,7 +60,11 @@ class BloomFilterPolicy : public FilterPolicy {
     for (size_t i = 0; i < n; i++) {
       // Use double-hashing to generate a sequence of hash values.
       // See analysis in [Kirsch,Mitzenmacher 2006].
+#if 0
       uint32_t h = BloomHash(keys[i]);
+#else
+      uint32_t h = *(uint32_t *)keys[i].data();
+#endif
       const uint32_t delta = (h >> 17) | (h << 15);  // Rotate right 17 bits
       for (size_t j = 0; j < k_; j++) {
         const uint32_t bitpos = h % bits;

--- a/util/bloom.cc
+++ b/util/bloom.cc
@@ -34,6 +34,15 @@ class BloomFilterPolicy : public FilterPolicy {
     return "leveldb.BuiltinBloomFilter";
   }
 
+  virtual Slice TransformKey(const Slice & Key, std::string & Buffer) const
+  {
+      uint32_t hash;
+
+      hash=BloomHash(ExtractUserKey(Key));
+      Buffer.assign((char *)&hash, sizeof(hash));
+      return(Slice(Buffer));
+  };
+
   virtual void CreateFilter(const Slice* keys, int n, std::string* dst) const {
     // Compute bloom filter size (in both bits and bytes)
     size_t bits = n * bits_per_key_;
@@ -52,7 +61,11 @@ class BloomFilterPolicy : public FilterPolicy {
     for (size_t i = 0; i < (size_t)n; i++) {
       // Use double-hashing to generate a sequence of hash values.
       // See analysis in [Kirsch,Mitzenmacher 2006].
+#if 0
       uint32_t h = BloomHash(keys[i]);
+#else
+      uint32_t h = *(uint32_t *)keys[i].data();
+#endif
       const uint32_t delta = (h >> 17) | (h << 15);  // Rotate right 17 bits
       for (size_t j = 0; j < k_; j++) {
         const uint32_t bitpos = h % bits;

--- a/util/bloom.cc
+++ b/util/bloom.cc
@@ -38,7 +38,7 @@ class BloomFilterPolicy : public FilterPolicy {
   {
       uint32_t hash;
 
-      hash=BloomHash(ExtractUserKey(Key));
+      hash=BloomHash(Key);
       Buffer.assign((char *)&hash, sizeof(hash));
       return(Slice(Buffer));
   };

--- a/util/bloom.cc
+++ b/util/bloom.cc
@@ -38,7 +38,7 @@ class BloomFilterPolicy : public FilterPolicy {
   {
       uint32_t hash;
 
-      hash=BloomHash(Key);
+      hash=BloomHash(ExtractUserKey(Key));
       Buffer.assign((char *)&hash, sizeof(hash));
       return(Slice(Buffer));
   };
@@ -62,7 +62,6 @@ class BloomFilterPolicy : public FilterPolicy {
       // Use double-hashing to generate a sequence of hash values.
       // See analysis in [Kirsch,Mitzenmacher 2006].
       uint32_t h = *(uint32_t *)keys[i].data();
-
       const uint32_t delta = (h >> 17) | (h << 15);  // Rotate right 17 bits
       for (size_t j = 0; j < k_; j++) {
         const uint32_t bitpos = h % bits;

--- a/util/bloom.cc
+++ b/util/bloom.cc
@@ -61,11 +61,7 @@ class BloomFilterPolicy : public FilterPolicy {
     for (size_t i = 0; i < (size_t)n; i++) {
       // Use double-hashing to generate a sequence of hash values.
       // See analysis in [Kirsch,Mitzenmacher 2006].
-#if 0
-      uint32_t h = BloomHash(keys[i]);
-#else
       uint32_t h = *(uint32_t *)keys[i].data();
-#endif
       const uint32_t delta = (h >> 17) | (h << 15);  // Rotate right 17 bits
       for (size_t j = 0; j < k_; j++) {
         const uint32_t bitpos = h % bits;

--- a/util/bloom2.cc
+++ b/util/bloom2.cc
@@ -47,8 +47,8 @@ class BloomFilterPolicy2 : public FilterPolicy {
   {
       uint32_t hash0, hash1;
 
-      hash0=BloomHash0(ExtractUserKey(Key));
-      hash1=BloomHash1(ExtractUserKey(Key));
+      hash0=BloomHash0(Key);
+      hash1=BloomHash1(Key);
       Buffer.assign((char *)&hash0, sizeof(hash0));
       Buffer.append((char *)&hash1, sizeof(hash1));
       return(Slice(Buffer));

--- a/util/bloom2.cc
+++ b/util/bloom2.cc
@@ -116,7 +116,7 @@ class BloomFilterPolicy2 : public FilterPolicy {
     return true;
   }
 };
-}
+}; // namespace (blank)
 
 const FilterPolicy* NewBloomFilterPolicy2(int bits_per_key) {
   return new BloomFilterPolicy2(bits_per_key);

--- a/util/bloom2.cc
+++ b/util/bloom2.cc
@@ -115,7 +115,7 @@ class BloomFilterPolicy2 : public FilterPolicy {
     return true;
   }
 };
-}
+}; // namespace (blank)
 
 const FilterPolicy* NewBloomFilterPolicy2(int bits_per_key) {
   return new BloomFilterPolicy2(bits_per_key);

--- a/util/bloom2.cc
+++ b/util/bloom2.cc
@@ -43,6 +43,17 @@ class BloomFilterPolicy2 : public FilterPolicy {
     return "leveldb.BuiltinBloomFilter2";
   }
 
+  virtual Slice TransformKey(const Slice & Key, std::string & Buffer) const
+  {
+      uint32_t hash0, hash1;
+
+      hash0=BloomHash0(ExtractUserKey(Key));
+      hash1=BloomHash1(ExtractUserKey(Key));
+      Buffer.assign((char *)&hash0, sizeof(hash0));
+      Buffer.append((char *)&hash1, sizeof(hash1));
+      return(Slice(Buffer));
+  };
+
   virtual void CreateFilter(const Slice* keys, int n, std::string* dst) const
   {
     unsigned bytes;
@@ -63,8 +74,11 @@ class BloomFilterPolicy2 : public FilterPolicy {
     for (size_t i = 0; i < n; i++) {
       // Use double-hashing to generate a sequence of hash values.
       // See analysis in [Kirsch,Mitzenmacher 2006].
-      uint32_t h = BloomHash0(keys[i]);
-      uint32_t h2= BloomHash1(keys[i]);
+      const char * key_ptr;
+      key_ptr=keys[i].data();
+      uint32_t h = *(uint32_t *)key_ptr;
+      uint32_t h2= *(uint32_t *)(key_ptr+sizeof(uint32_t));
+
       const uint32_t delta = (h >> 17) | (h << 15);  // Rotate right 17 bits
       for (size_t j = 0; j < k_; j++) {
           const uint32_t bitpos = (h + ((j+1)*h2)) % prime;

--- a/util/bloom2.cc
+++ b/util/bloom2.cc
@@ -47,8 +47,8 @@ class BloomFilterPolicy2 : public FilterPolicy {
   {
       uint32_t hash0, hash1;
 
-      hash0=BloomHash0(Key);
-      hash1=BloomHash1(Key);
+      hash0=BloomHash0(ExtractUserKey(Key));
+      hash1=BloomHash1(ExtractUserKey(Key));
       Buffer.assign((char *)&hash0, sizeof(hash0));
       Buffer.append((char *)&hash1, sizeof(hash1));
       return(Slice(Buffer));

--- a/util/bloom_test.cc
+++ b/util/bloom_test.cc
@@ -37,7 +37,12 @@ class BloomTest {
   }
 
   void Add(const Slice& s) {
-    keys_.push_back(s.ToString());
+
+      std::string transform_temp;
+      Slice transform_key;
+
+      transform_key=policy_->TransformKey(s, transform_temp);
+      keys_.push_back(transform_temp);
   }
 
   void Build() {

--- a/util/crc32c.cc
+++ b/util/crc32c.cc
@@ -307,6 +307,7 @@ SoftCRC(uint32_t crc, const char* buf, size_t size)
   const uint8_t *p = reinterpret_cast<const uint8_t *>(buf);
   const uint8_t *e = p + size;
   uint32_t l = crc ^ 0xffffffffu;
+
 #define STEP1 do {                              \
     int c = (l & 0xff) ^ *p++;                  \
     l = table0_[c] ^ (l >> 8);                  \

--- a/util/crc32c.cc
+++ b/util/crc32c.cc
@@ -436,5 +436,48 @@ Crc32c(
 }   // Crc32c
 
 
+
+
+uint32_t
+Crc32c(
+    uint32_t StartCrc,
+    void * BlockStart,
+    size_t BlockSize)
+{
+    size_t fullqwords, remainder;
+    uint32_t ret_crc;
+    char * src_c;
+    uint64_t * src_q;
+
+    fullqwords=BlockSize / 8;
+    remainder=BlockSize % 8;
+
+//    remainder=BlockSize;
+
+    ret_crc=StartCrc;
+    src_q=(uint64_t *)BlockStart;
+#if 1
+    for ( ; 0!=fullqwords; --fullqwords, ++src_q)
+    {
+        __asm__ __volatile__ (
+            ".byte 0xf2, 0x48, 0x0f, 0x38, 0xf1, 0xf1;"
+            : "=S"(ret_crc)
+            : "S"(ret_crc), "c"(*src_q));
+    }   // for
+#endif
+    src_c=(char *)src_q;
+    for ( ; 0!=remainder; --remainder, ++src_c)
+    {
+        __asm__ __volatile__ (
+            ".byte 0xf2, 0x48, 0x0f, 0x38, 0xf0, 0xf1;"
+            : "=S"(ret_crc)
+            : "S"(ret_crc), "c"(*src_c));
+    }   // for
+
+    return(ret_crc);
+
+}   // Crc32c
+
+
 }  // namespace crc32c
 }  // namespace leveldb

--- a/util/crc32c.cc
+++ b/util/crc32c.cc
@@ -307,7 +307,7 @@ SoftCRC(uint32_t crc, const char* buf, size_t size)
   const uint8_t *p = reinterpret_cast<const uint8_t *>(buf);
   const uint8_t *e = p + size;
   uint32_t l = crc ^ 0xffffffffu;
-#if 1
+
 #define STEP1 do {                              \
     int c = (l & 0xff) ^ *p++;                  \
     l = table0_[c] ^ (l >> 8);                  \
@@ -391,136 +391,6 @@ HardCRC(
 #endif
 
 }   // HardCRC
-
-
-
-
-uint32_t
-Crc32c(
-    uint32_t StartCrc,
-    void * BlockStart,
-    size_t BlockSize)
-{
-    size_t fullqwords, remainder;
-    uint32_t ret_crc;
-    char * src_c;
-    uint64_t * src_q;
-
-    fullqwords=BlockSize / 8;
-    remainder=BlockSize % 8;
-
-//    remainder=BlockSize;
-
-    ret_crc=StartCrc;
-    src_q=(uint64_t *)BlockStart;
-#if 1
-    for ( ; 0!=fullqwords; --fullqwords, ++src_q)
-    {
-        __asm__ __volatile__ (
-            ".byte 0xf2, 0x48, 0x0f, 0x38, 0xf1, 0xf1;"
-            : "=S"(ret_crc)
-            : "S"(ret_crc), "c"(*src_q));
-    }   // for
-#endif
-    src_c=(char *)src_q;
-    for ( ; 0!=remainder; --remainder, ++src_c)
-    {
-        __asm__ __volatile__ (
-            ".byte 0xf2, 0x48, 0x0f, 0x38, 0xf0, 0xf1;"
-            : "=S"(ret_crc)
-            : "S"(ret_crc), "c"(*src_c));
-    }   // for
-
-    return(ret_crc);
-
-}   // Crc32c
-
-
-
-
-uint32_t
-Crc32c(
-    uint32_t StartCrc,
-    void * BlockStart,
-    size_t BlockSize)
-{
-    size_t fullqwords, remainder;
-    uint32_t ret_crc;
-    char * src_c;
-    uint64_t * src_q;
-
-    fullqwords=BlockSize / 8;
-    remainder=BlockSize % 8;
-
-//    remainder=BlockSize;
-
-    ret_crc=StartCrc;
-    src_q=(uint64_t *)BlockStart;
-#if 1
-    for ( ; 0!=fullqwords; --fullqwords, ++src_q)
-    {
-        __asm__ __volatile__ (
-            ".byte 0xf2, 0x48, 0x0f, 0x38, 0xf1, 0xf1;"
-            : "=S"(ret_crc)
-            : "S"(ret_crc), "c"(*src_q));
-    }   // for
-#endif
-    src_c=(char *)src_q;
-    for ( ; 0!=remainder; --remainder, ++src_c)
-    {
-        __asm__ __volatile__ (
-            ".byte 0xf2, 0x48, 0x0f, 0x38, 0xf0, 0xf1;"
-            : "=S"(ret_crc)
-            : "S"(ret_crc), "c"(*src_c));
-    }   // for
-
-    return(ret_crc);
-
-}   // Crc32c
-
-
-
-
-uint32_t
-Crc32c(
-    uint32_t StartCrc,
-    void * BlockStart,
-    size_t BlockSize)
-{
-    size_t fullqwords, remainder;
-    uint32_t ret_crc;
-    char * src_c;
-    uint64_t * src_q;
-
-    fullqwords=BlockSize / 8;
-    remainder=BlockSize % 8;
-
-//    remainder=BlockSize;
-
-    ret_crc=StartCrc;
-    src_q=(uint64_t *)BlockStart;
-#if 1
-    for ( ; 0!=fullqwords; --fullqwords, ++src_q)
-    {
-        __asm__ __volatile__ (
-            ".byte 0xf2, 0x48, 0x0f, 0x38, 0xf1, 0xf1;"
-            : "=S"(ret_crc)
-            : "S"(ret_crc), "c"(*src_q));
-    }   // for
-#endif
-    src_c=(char *)src_q;
-    for ( ; 0!=remainder; --remainder, ++src_c)
-    {
-        __asm__ __volatile__ (
-            ".byte 0xf2, 0x48, 0x0f, 0x38, 0xf0, 0xf1;"
-            : "=S"(ret_crc)
-            : "S"(ret_crc), "c"(*src_c));
-    }   // for
-
-    return(ret_crc);
-
-}   // Crc32c
-
 
 }  // namespace crc32c
 }  // namespace leveldb

--- a/util/crc32c.cc
+++ b/util/crc32c.cc
@@ -307,7 +307,6 @@ SoftCRC(uint32_t crc, const char* buf, size_t size)
   const uint8_t *p = reinterpret_cast<const uint8_t *>(buf);
   const uint8_t *e = p + size;
   uint32_t l = crc ^ 0xffffffffu;
-#if 1
 #define STEP1 do {                              \
     int c = (l & 0xff) ^ *p++;                  \
     l = table0_[c] ^ (l >> 8);                  \
@@ -391,93 +390,6 @@ HardCRC(
 #endif
 
 }   // HardCRC
-
-
-
-
-uint32_t
-Crc32c(
-    uint32_t StartCrc,
-    void * BlockStart,
-    size_t BlockSize)
-{
-    size_t fullqwords, remainder;
-    uint32_t ret_crc;
-    char * src_c;
-    uint64_t * src_q;
-
-    fullqwords=BlockSize / 8;
-    remainder=BlockSize % 8;
-
-//    remainder=BlockSize;
-
-    ret_crc=StartCrc;
-    src_q=(uint64_t *)BlockStart;
-#if 1
-    for ( ; 0!=fullqwords; --fullqwords, ++src_q)
-    {
-        __asm__ __volatile__ (
-            ".byte 0xf2, 0x48, 0x0f, 0x38, 0xf1, 0xf1;"
-            : "=S"(ret_crc)
-            : "S"(ret_crc), "c"(*src_q));
-    }   // for
-#endif
-    src_c=(char *)src_q;
-    for ( ; 0!=remainder; --remainder, ++src_c)
-    {
-        __asm__ __volatile__ (
-            ".byte 0xf2, 0x48, 0x0f, 0x38, 0xf0, 0xf1;"
-            : "=S"(ret_crc)
-            : "S"(ret_crc), "c"(*src_c));
-    }   // for
-
-    return(ret_crc);
-
-}   // Crc32c
-
-
-
-
-uint32_t
-Crc32c(
-    uint32_t StartCrc,
-    void * BlockStart,
-    size_t BlockSize)
-{
-    size_t fullqwords, remainder;
-    uint32_t ret_crc;
-    char * src_c;
-    uint64_t * src_q;
-
-    fullqwords=BlockSize / 8;
-    remainder=BlockSize % 8;
-
-//    remainder=BlockSize;
-
-    ret_crc=StartCrc;
-    src_q=(uint64_t *)BlockStart;
-#if 1
-    for ( ; 0!=fullqwords; --fullqwords, ++src_q)
-    {
-        __asm__ __volatile__ (
-            ".byte 0xf2, 0x48, 0x0f, 0x38, 0xf1, 0xf1;"
-            : "=S"(ret_crc)
-            : "S"(ret_crc), "c"(*src_q));
-    }   // for
-#endif
-    src_c=(char *)src_q;
-    for ( ; 0!=remainder; --remainder, ++src_c)
-    {
-        __asm__ __volatile__ (
-            ".byte 0xf2, 0x48, 0x0f, 0x38, 0xf0, 0xf1;"
-            : "=S"(ret_crc)
-            : "S"(ret_crc), "c"(*src_c));
-    }   // for
-
-    return(ret_crc);
-
-}   // Crc32c
-
 
 }  // namespace crc32c
 }  // namespace leveldb

--- a/util/crc32c.cc
+++ b/util/crc32c.cc
@@ -283,11 +283,18 @@ static inline uint32_t LE_LOAD32(const uint8_t *p) {
   return DecodeFixed32(reinterpret_cast<const char*>(p));
 }
 
+
+uint32_t
+Crc32c(
+    uint32_t StartCrc,
+    void * BlockStart,
+    size_t BlockSize);
+
 uint32_t Extend(uint32_t crc, const char* buf, size_t size) {
   const uint8_t *p = reinterpret_cast<const uint8_t *>(buf);
   const uint8_t *e = p + size;
   uint32_t l = crc ^ 0xffffffffu;
-
+#if 0
 #define STEP1 do {                              \
     int c = (l & 0xff) ^ *p++;                  \
     l = table0_[c] ^ (l >> 8);                  \
@@ -325,8 +332,56 @@ uint32_t Extend(uint32_t crc, const char* buf, size_t size) {
   }
 #undef STEP4
 #undef STEP1
+
+#else
+  l=Crc32c(crc ^ 0xffffffffu, (void*)buf, size);
+#endif
+
   return l ^ 0xffffffffu;
 }
+
+
+
+uint32_t
+Crc32c(
+    uint32_t StartCrc,
+    void * BlockStart,
+    size_t BlockSize)
+{
+    size_t fullqwords, remainder;
+    uint32_t ret_crc;
+    char * src_c;
+    uint64_t * src_q;
+
+    fullqwords=BlockSize / 8;
+    remainder=BlockSize % 8;
+
+//    remainder=BlockSize;
+
+    ret_crc=StartCrc;
+    src_q=(uint64_t *)BlockStart;
+#if 1
+    for ( ; 0!=fullqwords; --fullqwords, ++src_q)
+    {
+        __asm__ __volatile__ (
+            ".byte 0xf2, 0x48, 0x0f, 0x38, 0xf1, 0xf1;"
+            : "=S"(ret_crc)
+            : "S"(ret_crc), "c"(*src_q));
+    }   // for
+#endif
+    src_c=(char *)src_q;
+    for ( ; 0!=remainder; --remainder, ++src_c)
+    {
+        __asm__ __volatile__ (
+            ".byte 0xf2, 0x48, 0x0f, 0x38, 0xf0, 0xf1;"
+            : "=S"(ret_crc)
+            : "S"(ret_crc), "c"(*src_c));
+    }   // for
+
+    return(ret_crc);
+
+}   // Crc32c
+
 
 }  // namespace crc32c
 }  // namespace leveldb

--- a/util/crc32c.cc
+++ b/util/crc32c.cc
@@ -307,7 +307,7 @@ SoftCRC(uint32_t crc, const char* buf, size_t size)
   const uint8_t *p = reinterpret_cast<const uint8_t *>(buf);
   const uint8_t *e = p + size;
   uint32_t l = crc ^ 0xffffffffu;
-#if 0
+#if 1
 #define STEP1 do {                              \
     int c = (l & 0xff) ^ *p++;                  \
     l = table0_[c] ^ (l >> 8);                  \

--- a/util/crc32c.cc
+++ b/util/crc32c.cc
@@ -294,7 +294,7 @@ uint32_t Extend(uint32_t crc, const char* buf, size_t size) {
   const uint8_t *p = reinterpret_cast<const uint8_t *>(buf);
   const uint8_t *e = p + size;
   uint32_t l = crc ^ 0xffffffffu;
-#if 0
+#if 1
 #define STEP1 do {                              \
     int c = (l & 0xff) ^ *p++;                  \
     l = table0_[c] ^ (l >> 8);                  \

--- a/util/crc32c.cc
+++ b/util/crc32c.cc
@@ -307,7 +307,7 @@ SoftCRC(uint32_t crc, const char* buf, size_t size)
   const uint8_t *p = reinterpret_cast<const uint8_t *>(buf);
   const uint8_t *e = p + size;
   uint32_t l = crc ^ 0xffffffffu;
-
+#if 0
 #define STEP1 do {                              \
     int c = (l & 0xff) ^ *p++;                  \
     l = table0_[c] ^ (l >> 8);                  \
@@ -391,6 +391,49 @@ HardCRC(
 #endif
 
 }   // HardCRC
+
+
+
+
+uint32_t
+Crc32c(
+    uint32_t StartCrc,
+    void * BlockStart,
+    size_t BlockSize)
+{
+    size_t fullqwords, remainder;
+    uint32_t ret_crc;
+    char * src_c;
+    uint64_t * src_q;
+
+    fullqwords=BlockSize / 8;
+    remainder=BlockSize % 8;
+
+//    remainder=BlockSize;
+
+    ret_crc=StartCrc;
+    src_q=(uint64_t *)BlockStart;
+#if 1
+    for ( ; 0!=fullqwords; --fullqwords, ++src_q)
+    {
+        __asm__ __volatile__ (
+            ".byte 0xf2, 0x48, 0x0f, 0x38, 0xf1, 0xf1;"
+            : "=S"(ret_crc)
+            : "S"(ret_crc), "c"(*src_q));
+    }   // for
+#endif
+    src_c=(char *)src_q;
+    for ( ; 0!=remainder; --remainder, ++src_c)
+    {
+        __asm__ __volatile__ (
+            ".byte 0xf2, 0x48, 0x0f, 0x38, 0xf0, 0xf1;"
+            : "=S"(ret_crc)
+            : "S"(ret_crc), "c"(*src_c));
+    }   // for
+
+    return(ret_crc);
+
+}   // Crc32c
 
 
 }  // namespace crc32c

--- a/util/env_posix.cc
+++ b/util/env_posix.cc
@@ -34,6 +34,8 @@
 
 #include "util/env_riak.h"
 
+#include "util/env_riak.h"
+
 #if _XOPEN_SOURCE >= 600 || _POSIX_C_SOURCE >= 200112L
 #define HAVE_FADVISE
 #endif
@@ -157,26 +159,6 @@ namespace {
 static Status IOError(const std::string& context, int err_number) {
   return Status::IOError(context, strerror(err_number));
 }
-
-
-// background routines to close and/or unmap files
-static void BGFileCloser(void* file_info);
-static void BGFileCloser2(void* file_info);
-// currently unused static void BGFileUnmapper(void* file_info);
-static void BGFileUnmapper2(void* file_info);
-
-// data needed by background routines for close/unmap
-struct BGCloseInfo
-{
-    int fd_;
-    void * base_;
-    size_t offset_;
-    size_t length_;
-    size_t unused_;
-
-    BGCloseInfo(int fd, void * base, size_t offset, size_t length, size_t unused)
-        : fd_(fd), base_(base), offset_(offset), length_(length), unused_(unused) {};
-};
 
 class PosixSequentialFile: public SequentialFile {
  private:

--- a/util/env_posix.cc
+++ b/util/env_posix.cc
@@ -26,6 +26,7 @@
 #include "port/port.h"
 #include "util/crc32c.h"
 #include "util/logging.h"
+#include "util/mapbuffer.h"
 #include "util/posix_logger.h"
 #include "db/dbformat.h"
 #include "leveldb/perf_count.h"
@@ -567,7 +568,7 @@ class PosixEnv : public Env {
             RiakBufferFile * new_file;
 
             new_file=new RiakBufferFile;
-            s=new_file->Open(fname, AdviseKeep, WriteBufferSize);
+            s=new_file->Open(fname, AdviseKeep, WriteBufferSize, page_size_);
 
             if (s.ok())
                 *result=new_file;
@@ -579,7 +580,7 @@ class PosixEnv : public Env {
     // param error
     else
     {
-        s=Status::InvalidArguement(Slice("NewWritableFile():  bad parameter."));
+        s=Status::InvalidArgument(Slice("NewWritableFile():  bad parameter."));
     }   // else
 
     return s;

--- a/util/env_posix.cc
+++ b/util/env_posix.cc
@@ -24,6 +24,7 @@
 #include "leveldb/slice.h"
 #include "port/port.h"
 #include "util/logging.h"
+#include "util/mapbuffer.h"
 #include "util/posix_logger.h"
 #include "db/dbformat.h"
 
@@ -450,7 +451,7 @@ class PosixEnv : public Env {
             RiakBufferFile * new_file;
 
             new_file=new RiakBufferFile;
-            s=new_file->Open(fname, AdviseKeep, WriteBufferSize);
+            s=new_file->Open(fname, AdviseKeep, WriteBufferSize, page_size_);
 
             if (s.ok())
                 *result=new_file;
@@ -462,7 +463,7 @@ class PosixEnv : public Env {
     // param error
     else
     {
-        s=Status::InvalidArguement(Slice("NewWritableFile():  bad parameter."));
+        s=Status::InvalidArgument(Slice("NewWritableFile():  bad parameter."));
     }   // else
 
     return s;

--- a/util/env_posix.cc
+++ b/util/env_posix.cc
@@ -30,12 +30,6 @@
 #include "util/posix_logger.h"
 #include "db/dbformat.h"
 #include "leveldb/perf_count.h"
-
-#include <syslog.h>
-#include "leveldb/perf_count.h"
-
-#include "util/env_riak.h"
-
 #include "util/env_riak.h"
 
 #if _XOPEN_SOURCE >= 600 || _POSIX_C_SOURCE >= 200112L

--- a/util/env_posix.cc
+++ b/util/env_posix.cc
@@ -26,6 +26,7 @@
 #include "port/port.h"
 #include "util/crc32c.h"
 #include "util/logging.h"
+#include "util/mapbuffer.h"
 #include "util/posix_logger.h"
 #include "db/dbformat.h"
 #include "leveldb/perf_count.h"
@@ -461,7 +462,7 @@ class PosixEnv : public Env {
             RiakBufferFile * new_file;
 
             new_file=new RiakBufferFile;
-            s=new_file->Open(fname, AdviseKeep, WriteBufferSize);
+            s=new_file->Open(fname, AdviseKeep, WriteBufferSize, page_size_);
 
             if (s.ok())
                 *result=new_file;
@@ -473,7 +474,7 @@ class PosixEnv : public Env {
     // param error
     else
     {
-        s=Status::InvalidArguement(Slice("NewWritableFile():  bad parameter."));
+        s=Status::InvalidArgument(Slice("NewWritableFile():  bad parameter."));
     }   // else
 
     return s;

--- a/util/env_posix.cc
+++ b/util/env_posix.cc
@@ -21,12 +21,15 @@
 #include <sys/stat.h>
 #endif
 #include "leveldb/env.h"
+#include "leveldb/filter_policy.h"
 #include "leveldb/slice.h"
 #include "port/port.h"
 #include "util/logging.h"
 #include "util/mapbuffer.h"
 #include "util/posix_logger.h"
 #include "db/dbformat.h"
+
+#include "util/env_riak.h"
 
 #if _XOPEN_SOURCE >= 600 || _POSIX_C_SOURCE >= 200112L
 #define HAVE_FADVISE
@@ -42,25 +45,6 @@ namespace {
 static Status IOError(const std::string& context, int err_number) {
   return Status::IOError(context, strerror(err_number));
 }
-
-// background routines to close and/or unmap files
-static void BGFileCloser(void* file_info);
-static void BGFileCloser2(void* file_info);
-static void BGFileUnmapper(void* file_info);
-static void BGFileUnmapper2(void* file_info);
-
-// data needed by background routines for close/unmap
-struct BGCloseInfo
-{
-    int fd_;
-    void * base_;
-    size_t offset_;
-    size_t length_;
-    size_t unused_;
-
-    BGCloseInfo(int fd, void * base, size_t offset, size_t length, size_t unused)
-        : fd_(fd), base_(base), offset_(offset), length_(length), unused_(unused) {};
-};
 
 class PosixSequentialFile: public SequentialFile {
  private:
@@ -427,7 +411,7 @@ class PosixEnv : public Env {
   virtual Status NewWritableFile(const std::string& fname,
                                  WritableFile** result,
                                  bool AdviseKeep,
-                                 const size_t WriteBufferSize) 
+                                 const size_t WriteBufferSize)
 {
     Status s;
 
@@ -902,6 +886,8 @@ void PosixEnv::StartThread(void (*function)(void* arg), void* arg) {
               pthread_create(&t, NULL,  &StartThreadWrapper, state));
 }
 
+}  // namespace
+
 // this was a reference file:  unmap, purge page cache, close
 void BGFileCloser(void * arg)
 {
@@ -958,7 +944,8 @@ void BGFileUnmapper(void * arg)
     munmap(file_ptr->base_, file_ptr->length_);
 
 #if defined(HAVE_FADVISE)
-    posix_fadvise(file_ptr->fd_, file_ptr->offset_, file_ptr->length_, POSIX_FADV_DONTNEED);
+    if (-1 != file_ptr->fd_)
+        posix_fadvise(file_ptr->fd_, file_ptr->offset_, file_ptr->length_, POSIX_FADV_DONTNEED);
 #endif
 
     delete file_ptr;
@@ -977,7 +964,8 @@ void BGFileUnmapper2(void * arg)
     munmap(file_ptr->base_, file_ptr->length_);
 
 #if defined(HAVE_FADVISE)
-    posix_fadvise(file_ptr->fd_, file_ptr->offset_, file_ptr->length_, POSIX_FADV_WILLNEED);
+    if (-1 != file_ptr->fd_)
+        posix_fadvise(file_ptr->fd_, file_ptr->offset_, file_ptr->length_, POSIX_FADV_WILLNEED);
 #endif
 
     delete file_ptr;
@@ -986,7 +974,6 @@ void BGFileUnmapper2(void * arg)
 
 }   // BGFileUnmapper2
 
-}  // namespace
 
 // how many blocks of 4 priority background threads/queues
 /// for riak, make sure this is an odd number (and especially not 4)
@@ -1006,6 +993,14 @@ static void InitDefaultEnv()
 
     pthread_rwlock_init(&gThreadLock0, NULL);
     pthread_rwlock_init(&gThreadLock1, NULL);
+
+    // force the loading of code for both filters in case they
+    //  are hidden in a shared library
+    const FilterPolicy * ptr;
+    ptr=NewBloomFilterPolicy(16);
+    delete ptr;
+    ptr=NewBloomFilterPolicy2(16);
+    delete ptr;
 
 }
 

--- a/util/env_posix.cc
+++ b/util/env_posix.cc
@@ -1293,14 +1293,6 @@ static void InitDefaultEnv()
 
     PerformanceCounters::Init(false);
 
-    // force the loading of code for both filters in case they
-    //  are hidden in a shared library
-    const FilterPolicy * ptr;
-    ptr=NewBloomFilterPolicy(16);
-    delete ptr;
-    ptr=NewBloomFilterPolicy2(16);
-    delete ptr;
-
 }
 
 Env* Env::Default() {

--- a/util/env_posix.cc
+++ b/util/env_posix.cc
@@ -1207,7 +1207,7 @@ void BGFileCloser2(void * arg)
 
 }   // BGFileCloser2
 
-#if 0  // currently unused, remove due to compiler warning
+
 // this was a reference file:  unmap, purge page cache
 void BGFileUnmapper(void * arg)
 {
@@ -1218,8 +1218,8 @@ void BGFileUnmapper(void * arg)
     munmap(file_ptr->base_, file_ptr->length_);
 
 #if defined(HAVE_FADVISE)
-    if (-1 != file_ptr->fd_)
-        posix_fadvise(file_ptr->fd_, file_ptr->offset_, file_ptr->length_, POSIX_FADV_DONTNEED);
+//    if (-1 != file_ptr->fd_)
+//        posix_fadvise(file_ptr->fd_, file_ptr->offset_, file_ptr->length_, POSIX_FADV_DONTNEED);
 #endif
 
     delete file_ptr;
@@ -1228,7 +1228,7 @@ void BGFileUnmapper(void * arg)
     return;
 
 }   // BGFileUnmapper
-#endif
+
 
 // this was a new file:  unmap, hold in page cache
 void BGFileUnmapper2(void * arg)

--- a/util/env_posix.cc
+++ b/util/env_posix.cc
@@ -435,15 +435,47 @@ class PosixEnv : public Env {
   }
 
   virtual Status NewWritableFile(const std::string& fname,
-                                 WritableFile** result) {
+                                 WritableFile** result,
+                                 bool AdviseKeep,
+                                 const size_t WriteBufferSize) 
+{
     Status s;
-    const int fd = open(fname.c_str(), O_CREAT | O_RDWR | O_TRUNC, 0644);
-    if (fd < 0) {
-      *result = NULL;
-      s = IOError(fname, errno);
-    } else {
-      *result = new PosixMmapFile(fname, fd, page_size_);
-    }
+
+    if (NULL!=result && 0!=fname.length())
+    {
+        // legacy use cases will have zero as the WriteBufferSize
+        if (0==WriteBufferSize)
+        {
+            const int fd = open(fname.c_str(), O_CREAT | O_RDWR | O_TRUNC, 0644);
+            if (fd < 0) {
+                *result = NULL;
+                s = IOError(fname, errno);
+            } else {
+                *result = new PosixMmapFile(fname, fd, page_size_);
+            }
+        }   // if
+
+        // update code will use overlapped writes
+        else
+        {
+            RiakBufferFile * new_file;
+
+            new_file=new RiakBufferFile;
+            s=new_file->Open(fname, AdviseKeep, WriteBufferSize);
+
+            if (s.ok())
+                *result=new_file;
+            else
+                *result=NULL;  // redundant, but safe
+        }   // else
+    }   // if
+
+    // param error
+    else
+    {
+        s=Status::InvalidArguement(Slice("NewWritableFile():  bad parameter."));
+    }   // else
+
     return s;
   }
 

--- a/util/env_posix.cc
+++ b/util/env_posix.cc
@@ -541,15 +541,47 @@ class PosixEnv : public Env {
   }
 
   virtual Status NewWritableFile(const std::string& fname,
-                                 WritableFile** result) {
+                                 WritableFile** result,
+                                 bool AdviseKeep,
+                                 const size_t WriteBufferSize) 
+{
     Status s;
-    const int fd = open(fname.c_str(), O_CREAT | O_RDWR | O_TRUNC, 0644);
-    if (fd < 0) {
-      *result = NULL;
-      s = IOError(fname, errno);
-    } else {
-      *result = new PosixMmapFile(fname, fd, page_size_);
-    }
+
+    if (NULL!=result && 0!=fname.length())
+    {
+        // legacy use cases will have zero as the WriteBufferSize
+        if (0==WriteBufferSize)
+        {
+            const int fd = open(fname.c_str(), O_CREAT | O_RDWR | O_TRUNC, 0644);
+            if (fd < 0) {
+                *result = NULL;
+                s = IOError(fname, errno);
+            } else {
+                *result = new PosixMmapFile(fname, fd, page_size_);
+            }
+        }   // if
+
+        // update code will use overlapped writes
+        else
+        {
+            RiakBufferFile * new_file;
+
+            new_file=new RiakBufferFile;
+            s=new_file->Open(fname, AdviseKeep, WriteBufferSize);
+
+            if (s.ok())
+                *result=new_file;
+            else
+                *result=NULL;  // redundant, but safe
+        }   // else
+    }   // if
+
+    // param error
+    else
+    {
+        s=Status::InvalidArguement(Slice("NewWritableFile():  bad parameter."));
+    }   // else
+
     return s;
   }
 

--- a/util/env_posix.cc
+++ b/util/env_posix.cc
@@ -30,11 +30,8 @@
 #include "util/posix_logger.h"
 #include "db/dbformat.h"
 #include "leveldb/perf_count.h"
-
-
 #include "util/env_riak.h"
 
-#include "util/env_riak.h"
 
 #if _XOPEN_SOURCE >= 600 || _POSIX_C_SOURCE >= 200112L
 #define HAVE_FADVISE

--- a/util/env_riak.h
+++ b/util/env_riak.h
@@ -1,0 +1,23 @@
+namespace leveldb {
+
+// background routines to close and/or unmap files
+void BGFileCloser(void* file_info);
+void BGFileCloser2(void* file_info);
+void BGFileUnmapper(void* file_info);
+void BGFileUnmapper2(void* file_info);
+
+// data needed by background routines for close/unmap
+struct BGCloseInfo
+{
+    int fd_;
+    void * base_;
+    size_t offset_;
+    size_t length_;
+    size_t unused_;
+
+    BGCloseInfo(int fd, void * base, size_t offset, size_t length, size_t unused)
+        : fd_(fd), base_(base), offset_(offset), length_(length), unused_(unused) {};
+};
+
+};  // namespace leveldb
+

--- a/util/filter_policy.cc
+++ b/util/filter_policy.cc
@@ -4,12 +4,13 @@
 
 #include "leveldb/filter_policy.h"
 #include "leveldb/slice.h"
+#include "db/dbformat.h"
 
 namespace leveldb {
 
 FilterPolicy::~FilterPolicy() { }
 
 Slice FilterPolicy::TransformKey(const Slice & Key, std::string & Buffer) const
-  {return(Key);};
+  {return(ExtractUserKey(Key));};
 
 }  // namespace leveldb

--- a/util/filter_policy.cc
+++ b/util/filter_policy.cc
@@ -4,13 +4,12 @@
 
 #include "leveldb/filter_policy.h"
 #include "leveldb/slice.h"
-#include "db/dbformat.h"
 
 namespace leveldb {
 
 FilterPolicy::~FilterPolicy() { }
 
 Slice FilterPolicy::TransformKey(const Slice & Key, std::string & Buffer) const
-  {return(ExtractUserKey(Key));};
+  {return(Key);};
 
 }  // namespace leveldb

--- a/util/filter_policy.cc
+++ b/util/filter_policy.cc
@@ -3,9 +3,14 @@
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
 #include "leveldb/filter_policy.h"
+#include "leveldb/slice.h"
+#include "db/dbformat.h"
 
 namespace leveldb {
 
 FilterPolicy::~FilterPolicy() { }
+
+Slice FilterPolicy::TransformKey(const Slice & Key, std::string & Buffer) const
+  {return(ExtractUserKey(Key));};
 
 }  // namespace leveldb

--- a/util/mapbuffer.cc
+++ b/util/mapbuffer.cc
@@ -204,8 +204,8 @@ RiakWriteBuffer::get(
     // just in case someone tries to get a pointer before writing:
     if (NULL!=m_Base)
     {
-        assert(m_Offset<=Offset && Offset<m_Offset+m_Size);
-        if (m_Offset<=Offset && Offset<m_Offset+m_Size)
+        assert(m_Offset<=Offset && Offset<m_Offset+(off_t)m_Size);
+        if (m_Offset<=Offset && Offset<m_Offset+(off_t)m_Size)
         {
             off_t map_offset;
 
@@ -550,9 +550,7 @@ RiakBufferFile::Allocate(
     {
         port::MutexLock lock(m_Mutex);
         off_t assigned_off;
-        bool done;
 
-        done=false;
         assigned_off=m_NextOffset;
         m_NextOffset+=DataSize;
 

--- a/util/mapbuffer.cc
+++ b/util/mapbuffer.cc
@@ -812,21 +812,6 @@ RiakBufferFile::UnMap(
 
 
 /**
- * Open file
- * @date 10/10/12 Created
- * @author matthewv
- */
-Status
-RiakBufferFile::Open(
-    const std::string & Filename,        //!< full path of file to create
-    bool AdviseKeep,                     //!< true for POSIX_FADV_WILLNEED, false _DONTNEED
-    size_t WriteBufferSize,              //!< will use this times 1.1 as default map size
-    size_t PageSize)                     //!< operating system page size
-{
-    Status ret_stat;
-
-
-/**
  * Perform sync requested by buffer
  * @date 10/12/12 Created
  * @author matthewv

--- a/util/mapbuffer.cc
+++ b/util/mapbuffer.cc
@@ -1,0 +1,428 @@
+/**
+ * @file mapbuffer.cc
+ * @author matthewv
+ * @date October 9, 2012
+ * @date Copyright (c) 2012 Basho Technologies, Inc. All Rights Reserved.
+ *
+ * @brief Implementations for overlapping writes to memmapped files
+ *
+ * This file is provided to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain
+ * a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+/**
+ * Initialize object
+ * @date 10/09/12 Created
+ * @author matthewv
+ */
+RiakWriteBuffer::RiakWriteBuffer(
+    RiakBufferFile & ParentFile)              //!< underlying file object
+    : m_RefCount(0), m_File(ParentFile),
+      m_Base(NULL), m_Offset(0), m_Size(0)
+{
+    return;
+}   // RiakWriteBuffer::RiakWriteBuffer
+
+
+/**
+ * Release resources
+ * @date 10/09/12 Created
+ * @author matthewv
+ */
+RiakWriteBuffer::~RiakWriteBuffer()
+{
+    assert(0==m_RefCount);  // otherwise pointers are about to be bad
+
+    if (NULL!=m_Base)
+    {
+        m_File.Unmap(m_Base, m_Size);
+    }   // if
+
+    return;
+
+}   // RiakWriteBuffer::~RiakWriteBuffer
+
+
+/**
+ * Copy data into memory mapping, potentially opening the mapping
+ * @date 10/09/12 Created
+ * @author matthewv
+ */
+Status
+RiakWriteBuffer::AssignData(
+    const void * Data,             //!< source to copy into map
+    size_t DataSize,               //!< number of bytes to copy
+    off_t AssignedOffset)          //!< offset from beginning of file where data goes
+{
+    Status ret_stat;
+
+    if (m_File.Status().ok)
+    {
+        {
+            MutexLock lock(m_MapWait);
+
+            // has someone performed the mapping?
+            //   first caller does it, other callers wait on mutex until map ready
+            if (NULL==m_Base)
+            {
+                // all actual file operation happen within file object
+                ret_stat=m_File.Map(m_Offset, m_Size, &m_Base);
+            }   // if
+        }   // MutexLock
+
+        assert(true==ret_stat.ok());
+        if (ret_stat.ok() && 0<DataSize)
+        {
+            // only copy if range valid
+            if (m_Offset<=AssignedOffset 
+                && AssignedOffset+DataSize<=m_Offset+m_Size)
+            {
+                off_t map_offset;
+                char * dst_ptr;
+
+                map_offset=AssignedOffset-m_Offset;
+                dst_ptr=(char *)m_Base + map_offset;
+                memcpy(dst_ptr, Data, DataSize);
+            }   // if
+            else
+            {
+                assert(false);
+                ret_stat=Status::InvalidArgument("AssignData: params outside mapping");
+            }   // else
+        }   // if
+    }   // if
+    else
+    {
+        ret_status=m_File.Status();
+    }   // else
+
+    return(ret_stat);
+
+}   // RiakWriteBuffer::AssignData
+
+
+/**
+ * Add one to our count of pointer references
+ * @date 10/10/12 Created
+ * @author matthewv
+ */
+Status
+RiakWriteBuffer::IncRef()
+{
+#ifdef OS_SOLARIS
+    atomic_add_int(&m_RefCount, 1);
+#else
+    __sync_add_and_fetch(&m_RefCount, 1);
+#endif
+
+    return;
+
+}   // RiakWriteBuffer::IncRef
+
+
+/**
+ * Remove one count and maybe delete self
+ * @date 10/10/12 Created
+ * @author matthewv
+ */
+Status
+RiakWriteBuffer::DecRef()
+{
+    if (0<m_RefCount && NULL!=m_Base)
+    {
+        int count;
+
+        assert(0<m_RefCount);
+
+#ifdef OS_SOLARIS
+        count=atomic_sub_int(&m_RefCount, 1);
+#else
+        count=__sync_sub_and_fetch(&m_RefCount, 1);
+#endif
+
+        if (0==count)
+        {
+            m_File.UnMap(m_Base, m_Size);
+            m_Base=NULL;
+            delete this;
+        }   // if
+    }   // if
+
+    return;
+
+}   // RiakWriteBuffer::DecRef
+
+
+/**
+ * Return a read pointer into buffer
+ * @date 10/10/12 Created
+ * @author matthewv
+ * @returns NULL or pointer to location in the buffer, no reference lock
+ */
+const void * 
+RiakWriteBuffer::get(
+    off_t Offset) const   //!< offset from beginning of file
+{
+    const void * ret_ptr;
+    
+    ret_ptr=NULL;
+
+    // just in case someone tries to get a pointer before writing:
+    if (NULL==m_Base)
+        AssignData(NULL, 0, Offset);
+
+    assert(m_Offset<=Offset && Offset<m_Offset+m_Size);
+    if (m_Offset<=Offset && Offset<m_Offset+m_Size)
+    {
+        off_t map_offset;
+
+        map_offset=Offset-m_Offset;
+        ret_ptr=(char *)m_Base + map_offset;
+    }   // if
+
+    return(ret_ptr);
+
+}   // RiakWriteBuffer::get
+
+
+/**
+ * Default constructor
+ * @date 10/10/12 Created
+ * @author matthewv
+ */
+RiakBufferPtr::RiakBufferPtr()
+    : m_Buffer(NULL), m_BaseOffset(0), m_BaseSize(0), 
+      m_CurOffset(NULL), m_CurSize(0)
+{
+    return;
+}   // RiakBufferPtr::RiakBufferPtr  (default)
+
+
+/**
+ * Copy constructor
+ * @date 10/10/12 Created
+ * @author matthewv
+ */
+RiakBufferPtr::RiakBufferPtr(
+    const RiakBufferPtr & Rhs)      //!< existing pointer to copy
+    : m_Buffer(NULL), m_BaseOffset(0), m_BaseSize(0), 
+      m_CurOffset(NULL), m_CurSize(0)
+{
+    *this=Rhs;
+
+    return;
+
+}   // RiakBufferPtr::RiakBufferPtr (copy)
+
+
+/**
+ * "new" Constructor with params
+ * @date 10/10/12 Created
+ * @author matthewv
+ */
+RiakBufferPtr::RiakBufferPtr(
+    RiakWriteBuffer & Buffer,
+    off_t PointerBase,
+    size_t PointerSize)
+    : m_Buffer(&Buffer), m_BaseOffset(PointerBase), m_BaseSize(PointerSize), 
+      m_CurOffset(NULL), m_CurSize(0)
+{
+    m_Buffer->IncRef();
+
+    return;
+
+}   // RiakBufferPtr::RiakBufferPtr (full creation)
+
+
+/**
+ * Release resources
+ * @date 10/10/12 Created
+ * @author matthewv
+ */
+RiakBufferPtr::~RiakBufferPtr()
+{
+    if (NULL!=m_Buffer)
+        m_Buffer->DecRef();
+
+    m_Buffer=NULL;
+    m_BaseOffset=0;
+
+    return;
+
+}   // RiakBufferPtr::~RiakBufferPtr
+
+
+/**
+ * Assignment/Copy another pointer
+ * @date 10/10/12 Created
+ * @author matthewv
+ * @returns reference to self
+ */
+RiakBufferPtr &
+RiakBufferPtr::operator=(
+    const RiakBufferPtr & rhs)
+{
+    bool same;
+
+    same=(rhs.m_Buffer==m_Buffer && rhs.m_BaseOffset==m_BaseOffset);
+
+    // release current buffer if assigned and not same as copy
+    if (NULL!=m_Buffer && !same)
+        m_Buffer->DecRef();
+
+    m_Buffer=rhs.m_Buffer;
+    m_BaseOffset=rhs.m_BaseOffset;
+    m_BaseSize=rhs.m_BaseSize;
+    m_CurOffset=rhs.m_CurOffset;
+    m_CurSize=rhs.m_CurSize;
+
+    if (NULL!=m_Buffer && !same)
+        m_Buffer->IncRef();
+    
+    return(*this);
+
+}   // RiakBufferPtr::operator=
+
+
+/**
+ * Copy data to beginning of allocated space
+ * @date 10/10/12 Created
+ * @author matthewv
+ * @returns Status error (either file ioerr or param error)
+ */
+Status
+RiakBufferPtr::assign(
+    void * Data,
+    size_t DataSize)
+{
+    Status ret_stat;
+
+    if (NULL!=m_Buffer && DataSize<=m_BaseSize 
+        && (NULL!=Data || 0==DataSize))
+    {
+        if (0!=DataSize)
+            m_Buffer->AssignData(Data, DataSize, m_BaseOffset);
+
+        m_CurOffset=m_BaseOffset+DataSize;
+        m_CurSize=m_BaseSize-DataSize;
+        
+    }   // if
+    else
+    {
+        ret_stat=Status::InvalidArgument("assign: params outside mapping");
+    }   // else
+
+    return(ret_stat);
+
+}   // RiakBufferPtr::assign
+
+
+/**
+ * Copy data after previous data on this pointer
+ * @date 10/10/12 Created
+ * @author matthewv
+ * @returns Status error (either file ioerr or param error)
+ */
+Status
+RiakBufferPtr::append(
+    void * Data,
+    size_t DataSize)
+{
+    Status ret_stat;
+
+    if (NULL!=m_Buffer && DataSize<=m_CurSize 
+        && (NULL!=Data || 0==DataSize))
+    {
+        if (0!=DataSize)
+            m_Buffer->AssignData(Data, DataSize, m_CurOffset);
+
+        m_CurOffset+=DataSize;
+        m_CurSize-=DataSize;
+        
+    }   // if
+    else
+    {
+        ret_stat=Status::InvalidArgument("append: params outside mapping");
+    }   // else
+
+    return(ret_stat);
+
+}   // RiakBufferPtr::append
+
+
+
+
+#if 0
+// pointer to a map  RiakWritePtr (derived from WritePtr)
+/// pointer to object
+/// offset in object or total space
+/// CopyFirst, CopyNext (assign / append) ... calls object and maybe blocks
+/// get() ... fails / asserts / throws if CopyTo not complete,
+///           OR gives const pointer where next assign will write
+/// ok(), writable() until full, readable() after full
+/// release() ... !ok, !writable, !readable
+
+// container RiakBufferFile
+/// pointer to current map, ref counted ptr
+/// rw lock for map tests
+//// obtain read lock
+//// validate global status ... assert & return if closed (or not open)
+//// assert a mapping exists
+//// inc reference lock on current map
+//// atomic offset / allocate
+//// allocation within current map
+//// yes, done ... create and return WritePtr
+//// no, release reference, then read lock
+//// get write lock,
+//// reference lock, retest ... if now good, release write lock & return ptr
+////  otherwise release object hold on current map, create new map starting
+////  at this caller's point for MIN(caller's size, buffer standard size)
+////  MUST make FTRUNCATE call here, not thread delayed (at map object)
+/// mutex close or abort? ... old 
+/// atomic offset counter
+/// is this the file object ... yes
+/// fadvise param
+/// close sync or async ... sync for now.  ftruncate to current offset
+//// use write lock, change global status and shutdown
+//// mutex on Close to allow clean unmaps? Or assume something else synchronizes
+////  writers to closer ... assert if current map has pointers outstanding, besides file's ptr?
+/// Should open create first mapping? only loss is if first object greater than entire mapping.
+////  yes, establish assumption one mapping always exists
+////  a background worker could be launched to seed new map ... cost/benefit? use zero size mapping?
+////  this would anticipate ftruncate only in cases where objects exactly fill current map. 
+////   put in comment, but do not code.  a testing bitch
+/// Open / Close ... allow stack object creation
+/// container level status: m_Status
+
+
+
+/// WritableFile needs "allocate pointer"
+///  WritePtr allocate(size_t)
+///  Fail Write() interface
+
+// NewWritableFile AND NewRiakWritableFile static ???
+///  or choose based upon WriteBufferSize ... zero is old PosixMmapFile
+///     call NewWritableFileOld (not virtual)
+/// hack into existing PosixEnv ... but keep stuff in other files.
+
+
+virtual Status NewWritableFile(  // only wraps "new" and Open call (delete obj if open fails)
+    const std::string &fname, 
+    WritableFile **result, 
+    bool AdviseKeep=false,
+    const size_t WriteBufferSize=0); // use write buffer size * 1.2
+
+
+#endif

--- a/util/mapbuffer.cc
+++ b/util/mapbuffer.cc
@@ -812,6 +812,21 @@ RiakBufferFile::UnMap(
 
 
 /**
+ * Open file
+ * @date 10/10/12 Created
+ * @author matthewv
+ */
+Status
+RiakBufferFile::Open(
+    const std::string & Filename,        //!< full path of file to create
+    bool AdviseKeep,                     //!< true for POSIX_FADV_WILLNEED, false _DONTNEED
+    size_t WriteBufferSize,              //!< will use this times 1.1 as default map size
+    size_t PageSize)                     //!< operating system page size
+{
+    Status ret_stat;
+
+
+/**
  * Perform sync requested by buffer
  * @date 10/12/12 Created
  * @author matthewv
@@ -838,6 +853,7 @@ RiakBufferFile::MSync(
             m_FileOk=Status::InvalidArgument(Slice("RiakBufferFile::MSync() on invalid file"));
     }   // else;
 #endif
+
     return;
 
 }   // RiakBufferFile::MSync

--- a/util/mapbuffer.cc
+++ b/util/mapbuffer.cc
@@ -443,7 +443,6 @@ RiakBufferPtr::append(
 
         m_CurOffset+=DataSize;
         m_CurSize-=DataSize;
-
     }   // if
     else
     {

--- a/util/mapbuffer.h
+++ b/util/mapbuffer.h
@@ -30,6 +30,8 @@
 namespace leveldb
 {
 
+class RiakBufferFile;
+
 class RiakWriteBuffer
 {
 public:

--- a/util/mapbuffer.h
+++ b/util/mapbuffer.h
@@ -148,10 +148,10 @@ public:
     RiakBufferFile();
     virtual ~RiakBufferFile();
 
-    virtual Status Open(const std::string & Filename, bool AdviseKeep, 
+    virtual Status Open(const std::string & Filename, bool AdviseKeep,
                         size_t WriteBufferSize, size_t PageSize);
 
-    RiakBufferPtr Allocate(size_t DataSize);
+    virtual Status Allocate(size_t DataSize, RiakBufferPtr & OutPtr);
 
     virtual Status Append(const Slice& data);
 

--- a/util/mapbuffer.h
+++ b/util/mapbuffer.h
@@ -30,8 +30,6 @@
 namespace leveldb
 {
 
-class RiakBufferFile;
-
 class RiakWriteBuffer
 {
 public:

--- a/util/mapbuffer.h
+++ b/util/mapbuffer.h
@@ -152,6 +152,7 @@ public:
                         size_t WriteBufferSize, size_t PageSize);
 
     virtual Status Allocate(size_t DataSize, RiakBufferPtr & OutPtr);
+    virtual bool SupportsBuilder2() const {return(true);};
 
     virtual Status Append(const Slice& data);
 

--- a/util/mapbuffer.h
+++ b/util/mapbuffer.h
@@ -1,0 +1,192 @@
+/**
+ * @file mapbuffer.h
+ * @author matthewv
+ * @date October 7, 2012
+ * @date Copyright (c) 2012 Basho Technologies, Inc. All Rights Reserved.
+ *
+ * @brief Declarations for overlapping writes to memmapped files
+ *
+ * This file is provided to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain
+ * a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <sys/mmap>
+
+#include <leveldb/status.h>
+
+
+namespace leveldb
+{
+
+class RiakWriteBuffer
+{
+public:
+
+protected:
+
+    volatile int m_RefCount;       //!< number of active users of this map, delete on zero
+    RiakBufferFile & m_File;   //!< parent file object
+
+    // mapping parameters
+    volatile void * m_Base;    //!< memory map location
+    off_t m_Offset;            //!< offset into m_File of m_Base
+    size_t m_Size;             //!< byte count of the mapping
+
+    Mutex m_MapWait;           //!< first assign actually performs mapping, others wait
+
+private:
+
+
+public:
+    explicit RiakWriteBuffer(RiakBufferFile & FileParent);
+
+    virtual ~RiakWriteBuffer();  // put unmap within file object
+
+    // method used to actually copy data into place (first thread also maps file)
+    Status AssignData(const void * Data, size_t DataSize, off_t AssignedOffset);
+
+    // update m_RefCount
+    void IncRef();
+
+    // update m_RefCount, potentially delete object (and unmap)
+    void DecRef();
+
+    // WARNING:  can return NULL
+    const void * get(off_t Offset) const;
+
+private:
+    RiakWriteBuffer();                                               //!< deny default constructor
+    RiakWriteBuffer(const RiakWriteBuffer & rhs);                    //!< deny copy
+    RiakWriteBuffer & operator=(const RiakWriteBuffer & rhs);  //!< deny assign
+
+};  // class RiakWriteBuffer
+
+
+class RiakBufferPtr
+{
+public:
+
+protected:
+    RiakWriteBuffer * m_Buffer;
+
+    off_t m_BaseOffset;       //!< offset assign to pointer
+    size_t m_BaseSize;        //!< size allocated to pointer
+
+    // no protection against multiple copies of pointer trying to overwrite
+    off_t m_CurOffset;        //!< current write position within assignment
+    size_t m_CurSize;         //!< remaining size within assignment
+
+
+public:
+    RiakBufferPtr();
+    RiakBufferPtr(RiakWriteBuffer & Buffer, off_t PointerBase, size_t PointerSize);
+    RiakBufferPtr(const RiakBufferPtr & rhs);
+
+    virtual ~RiakBufferPtr();
+
+    RiakBufferPtr & operator=(const RiakBufferPtr & rhs);
+
+    //
+    // stl like methods
+    //
+    const void * get() const {return(NULL!=m_Buffer ? m_Buffer->get(m_BaseOffset) : NULL);};
+    // ?? void release()?
+    bool ok() const {return(NULL!=m_Buffer);};
+
+    // is space still available for writing
+    bool writable() const {return(0!=m_CurSize);};
+
+    Status assign(void * Data, size_t DataSize);
+    Status append(void * Data, size_t DataSize);
+
+private:
+
+};  // class RiakBufferPtr
+
+#if 0
+// map   RiakWriteBuffer
+/// file object
+/// ref count
+//// if ref count goes to zero AND file next offset beyond range, delete
+////   on delete tell file object to remove from list
+//// OR file object holds one reference while in range, then releases
+/// creation mutex, all wait until mapping complete, first caller to 
+///  assign/append performs mapping ... allows mappings to be threaded on large blocks
+/// memcpy operation that verifies map offset and size
+/// mapping offset, size, pointer
+/// create UnMap routine in file object, call it on delete / background munmap
+
+// pointer to a map  RiakWritePtr (derived from WritePtr)
+/// pointer to object
+/// offset in object or total space
+/// CopyFirst, CopyNext (assign / append) ... calls object and maybe blocks
+/// get() ... fails / asserts / throws if CopyTo not complete,
+///           OR gives const pointer where next assign will write
+/// ok(), writable() until full, readable() after full
+/// release() ... !ok, !writable, !readable
+
+// container RiakBufferFile
+/// pointer to current map, ref counted ptr
+/// rw lock for map tests
+//// obtain read lock
+//// validate global status ... assert & return if closed (or not open)
+//// assert a mapping exists
+//// inc reference lock on current map
+//// atomic offset / allocate
+//// allocation within current map
+//// yes, done ... create and return WritePtr
+//// no, release reference, then read lock
+//// get write lock,
+//// reference lock, retest ... if now good, release write lock & return ptr
+////  otherwise release object hold on current map, create new map starting
+////  at this caller's point for MIN(caller's size, buffer standard size)
+////  MUST make FTRUNCATE call here, not thread delayed (at map object)
+/// mutex close or abort? ... old 
+/// atomic offset counter
+/// is this the file object ... yes
+/// fadvise param
+/// close sync or async ... sync for now.  ftruncate to current offset
+//// use write lock, change global status and shutdown
+//// mutex on Close to allow clean unmaps? Or assume something else synchronizes
+////  writers to closer ... assert if current map has pointers outstanding, besides file's ptr?
+/// Should open create first mapping? only loss is if first object greater than entire mapping.
+////  yes, establish assumption one mapping always exists
+////  a background worker could be launched to seed new map ... cost/benefit? use zero size mapping?
+////  this would anticipate ftruncate only in cases where objects exactly fill current map. 
+////   put in comment, but do not code.  a testing bitch
+/// Open / Close ... allow stack object creation
+/// container level status: m_Status
+
+
+
+/// WritableFile needs "allocate pointer"
+///  WritePtr allocate(size_t)
+///  Fail Write() interface
+
+// NewWritableFile AND NewRiakWritableFile static ???
+///  or choose based upon WriteBufferSize ... zero is old PosixMmapFile
+///     call NewWritableFileOld (not virtual)
+/// hack into existing PosixEnv ... but keep stuff in other files.
+
+
+virtual Status NewWritableFile(  // only wraps "new" and Open call (delete obj if open fails)
+    const std::string &fname, 
+    WritableFile **result, 
+    bool AdviseKeep=false,
+    const size_t WriteBufferSize=0); // use write buffer size * 1.2
+
+
+#endif
+
+};  // namespace leveldb

--- a/util/testutil.h
+++ b/util/testutil.h
@@ -37,13 +37,16 @@ class ErrorEnv : public EnvWrapper {
                num_writable_file_errors_(0) { }
 
   virtual Status NewWritableFile(const std::string& fname,
-                                 WritableFile** result) {
+                                 WritableFile** result,
+                                 bool AdviseKeep=false,
+                                 const size_t WriteBufferSize=0)
+   {
     if (writable_file_error_) {
       ++num_writable_file_errors_;
       *result = NULL;
       return Status::IOError(fname, "fake error");
     }
-    return target()->NewWritableFile(fname, result);
+    return target()->NewWritableFile(fname, result, AdviseKeep, WriteBufferSize);
   }
 };
 


### PR DESCRIPTION
This only improves performance in limited cases.  Not merging until it shows benefit in most or all cases.  March 2013 the limit appears to be in number of buffers between read and write side.

December 2013:  This code depends heavily upon passing data between two threads.  Subsequent work demonstrated that thread changes are extremely expensive within the Erlang VM.  Also the mv-hot-threads2 branch is now on master and gives better all round throughput for background operations.  Retiring this pull request.  Leaving the branch since it has a couple of useful memory mapped objects that could be useful for future non-blocking Write designs.
