### PR TITLE
access node level performance counters via GetProperty

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -1607,6 +1607,15 @@ bool DBImpl::GetProperty(const Slice& property, std::string* value) {
   } else if (in == "sstables") {
     *value = versions_->current()->DebugString();
     return true;
+  } else if (-1!=gPerfCounters->LookupCounter(in.ToString().c_str())) {
+
+      char buf[66];
+      int index;
+
+      index=gPerfCounters->LookupCounter(in.ToString().c_str());
+      snprintf(buf, sizeof(buf), "%llu", gPerfCounters->Value(index));
+      value->append(buf);
+      return(true);
   }
 
   return false;

--- a/include/leveldb/perf_count.h
+++ b/include/leveldb/perf_count.h
@@ -207,6 +207,8 @@ public:
 
     static const char * GetNamePtr(unsigned Index);
 
+    int LookupCounter(const char * Name);
+
     void Dump();
 
 };  // struct PerformanceCounters

--- a/util/perf_count.cc
+++ b/util/perf_count.cc
@@ -384,6 +384,26 @@ PerformanceCounters * gPerfCounters(&LocalStartupCounters);
     };
 
 
+    int
+    PerformanceCounters::LookupCounter(
+        const char * Name)
+    {
+        int index,loop;
+
+        index=-1;
+
+        if (NULL!=Name && '\0'!=*Name)
+        {
+            for (loop=0; loop<ePerfCountEnumSize && -1==index; ++loop)
+            {
+                if (0==strcmp(m_PerfCounterNames[loop], Name))
+                    index=loop;
+            }   // loop
+        }   // if
+
+        return(index);
+    };
+
     void
     PerformanceCounters::Dump()
     {


### PR DESCRIPTION
Sample code:

```
        std::string output;
        bool ret_flag;
        leveldb::DB * db_ptr;

        status=leveldb::DB::Open(options, dbname.c_str(), &db_ptr);
        if (status.ok())
        {
            leveldb::Slice prop;
            prop="leveldb.ApiOpen";
            ret_flag=db_ptr->GetProperty(prop, &output);
            printf("flag %d, value %s\n", (int)ret_flag, output.c_str());

            prop="leveldb.ReadBlockError";
            ret_flag=db_ptr->GetProperty(prop, &output);
            printf("flag %d, value %s\n", (int)ret_flag, output.c_str());

            prop="leveldb.Bob";
            ret_flag=db_ptr->GetProperty(prop, &output);
            printf("flag %d, value %s\n", (int)ret_flag, output.c_str());

            delete db_ptr;
        }   // if
```
