### PR TITLE
hack to counter unexplained condition where threads lack signals

### DIFF
--- a/util/env_posix.cc
+++ b/util/env_posix.cc
@@ -724,7 +724,9 @@ PosixEnv::Schedule(
 
     // If the queue is currently empty, the background thread may currently be
     // waiting.
-    if (queue_.empty() || queue2_.empty() || queue3_.empty() || queue4_.empty()) {
+// 11/20/12 - have seen background threads stuck with full queues and threads waiting
+//    if (queue_.empty() || queue2_.empty() || queue3_.empty() || queue4_.empty())
+    {
         PthreadCall("broadcast", pthread_cond_broadcast(&bgsignal_));
     }
 


### PR DESCRIPTION
Previous code would only signal compaction threads if work queues were busy.  The assumption was that the new work would be automatically picked up as threads returned from current work.  Only needed to signal if threads were not working and therefore sitting in a condition wait.

This change has every background work request send a signal, no matter what.  This would have activated the sleeping threads in Ryan's failure case.
