### PR TITLE
throttle version 3, working against 750 million population test

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -37,6 +37,7 @@
 #include "util/mutexlock.h"
 #include "leveldb/perf_count.h"
 
+
 namespace leveldb {
 
 // Information kept for every waiting writer
@@ -607,8 +608,11 @@ Status DBImpl::WriteLevel0Table(MemTable* mem, VersionEdit* edit,
 
   if (0!=meta.num_entries && s.ok())
   {
+      // This SetWriteRate() call removed because this thread
+      //  has priority (others blocked on mutex) and thus created
+      //  misleading estimates of disk write speed
       // 2x since mem to disk, not disk to disk
-      versions_->SetWriteRate(2*stats.micros/meta.num_entries);
+      //      env_->SetWriteRate(2*stats.micros/meta.num_entries);
   }   // if
 
   return s;
@@ -718,11 +722,12 @@ Status DBImpl::TEST_CompactMemTable() {
 void DBImpl::MaybeScheduleCompaction() {
   mutex_.AssertHeld();
 
-  int state;
+  int state, priority;
   bool push;
 
   // decide which background thread gets the compaction job
   state=0;
+  priority=0;
   push=false;
 
   // writing of memory to disk: high priority
@@ -739,7 +744,10 @@ void DBImpl::MaybeScheduleCompaction() {
 
       // compaction of level 0 files:  high priority
       if (NULL!=c_ptr && c_ptr->level()==0)
+      {
           push=true;
+          priority=versions_->NumLevelFiles(0);
+      }   // if
       delete c_ptr;
   }   // if
 
@@ -763,7 +771,7 @@ void DBImpl::MaybeScheduleCompaction() {
     // No work to be done
   } else {
     bg_compaction_scheduled_ = true;
-    env_->Schedule(&DBImpl::BGWork, this, state, (NULL!=imm_));
+    env_->Schedule(&DBImpl::BGWork, this, state, (NULL!=imm_), priority);
   }
 }
 
@@ -1014,8 +1022,6 @@ Status DBImpl::InstallCompactionResults(CompactionState* compact) {
 }
 
 Status DBImpl::DoCompactionWork(CompactionState* compact) {
-  const uint64_t start_micros = env_->NowMicros();
-  int64_t imm_micros = 0;  // Micros spent doing imm_ compactions
 
   Log(options_.info_log,  "Compacting %d@%d + %d@%d files",
       compact->compaction->num_input_files(0),
@@ -1037,6 +1043,9 @@ Status DBImpl::DoCompactionWork(CompactionState* compact) {
 
   if (0 == compact->compaction->level())
       pthread_rwlock_rdlock(&gThreadLock1);
+
+  const uint64_t start_micros = env_->NowMicros();
+  int64_t imm_micros = 0;  // Micros spent doing imm_ compactions
 
   Iterator* input = versions_->MakeInputIterator(compact->compaction);
   input->SeekToFirst();
@@ -1078,6 +1087,16 @@ Status DBImpl::DoCompactionWork(CompactionState* compact) {
       }
       compact->current_output()->largest.DecodeFrom(key);
       compact->builder->Add(key, input->value());
+
+      // update throttle ... now, end of compaction may be too late
+      //   but not too often since NowMicros can be costly
+      size_t entry_count;
+      entry_count=compact->num_entries + compact->builder->NumEntries();
+
+      // imm_micros intentional NOT removed from time calculation,
+      //  gives better measure of overall activity / write overhead
+      if (1==(entry_count % 1000) && 1000<entry_count)
+          env_->SetWriteRate((env_->NowMicros() - start_micros)/entry_count);
 
       // Close output file if it is big enough
       if (compact->builder->FileSize() >=
@@ -1122,8 +1141,10 @@ Status DBImpl::DoCompactionWork(CompactionState* compact) {
   stats_[compact->compaction->level() + 1].Add(stats);
 
   if (status.ok()) {
+    // imm_micros intentional NOT removed from time calculation,
+    //  gives better measure of overall activity / write overhead
     if (0!=compact->num_entries)
-      versions_->SetWriteRate(stats.micros/compact->num_entries);
+        env_->SetWriteRate(env_->NowMicros() - start_micros/compact->num_entries);
     status = InstallCompactionResults(compact);
   }
   VersionSet::LevelSummaryStorage tmp;
@@ -1479,7 +1500,7 @@ Status DBImpl::MakeRoomForWrite(bool force) {
   Status s;
   int throttle;
 
-  throttle=versions_->WriteThrottleUsec();
+  throttle=versions_->WriteThrottleUsec(bg_compaction_scheduled_);
   if (0!=throttle)
   {
       mutex_.Unlock();
@@ -1519,14 +1540,14 @@ Status DBImpl::MakeRoomForWrite(bool force) {
     } else if (imm_ != NULL) {
       // We have filled up the current memtable, but the previous
       // one is still being compacted, so we wait.
-      Log(options_.info_log, "waiting 2...\n");
+      Log(options_.info_log, "waiting 2... %d\n", throttle);
       gPerfCounters->Inc(ePerfWriteWaitImm);
       MaybeScheduleCompaction();
       bg_cv_.Wait();
       Log(options_.info_log, "running 2...\n");
     } else if (versions_->NumLevelFiles(0) >= config::kL0_StopWritesTrigger) {
       // There are too many level-0 files.
-      Log(options_.info_log, "waiting...\n");
+        Log(options_.info_log, "waiting...%d\n", throttle);
       gPerfCounters->Inc(ePerfWriteWaitLevel0);
       bg_cv_.Wait();
       Log(options_.info_log, "running...\n");

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -975,7 +975,10 @@ void VersionSet::Finalize(Version* v) {
 
       // don't screw around ... get data written to disk!
       if (config::kL0_SlowdownWritesTrigger <= v->files_[level].size())
+      {
           score*=1000000.0;
+          penalty+=v->files_[level].size() - config::kL0_SlowdownWritesTrigger +1;
+      }   // if
 
       // compute penalty for write throttle if too many Level-0 files accumulating
       if (config::kL0_CompactionTrigger <= v->files_[level].size())

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -217,13 +217,13 @@ class VersionSet {
 
   int WriteThrottleUsec(bool active_compaction)
   {
-      int penalty=current_->write_penalty_;
+      // background throttle in hundredths
+      uint64_t penalty=current_->write_penalty_ * 100;
       penalty+=env_->GetBackgroundBacklog();
       if (active_compaction)
-          ++penalty;
+          penalty+=100;
 
-      penalty*=3; // matthewv - 112812 trying to counter async NIF
-      return((int)(penalty * env_->GetWriteRate()));
+      return((int)env_->SmoothWriteRate((penalty * env_->GetWriteRate()))/100);
   }
 
 

--- a/include/leveldb/env.h
+++ b/include/leveldb/env.h
@@ -160,12 +160,15 @@ class Env {
   virtual void SleepForMicroseconds(int micros) = 0;
 
   // Where supported, give count of background jobs pending.
-  virtual int GetBackgroundBacklog() const {return(0);};
+  //  UNIT is HUNDREDTHS
+  virtual uint32_t GetBackgroundBacklog() const {return(0);};
 
   // Riak specific call.  Rate is microseconds spent writing
   // one key.  Usually the average time of many (like 1,000).
   // Set during background compaction, but not Level-0 write.
   virtual void SetWriteRate(uint64_t Rate) {};
+
+  virtual uint64_t SmoothWriteRate(uint64_t Rate) {return(Rate);};
 
   // Riak specific call.  Return the current "smoothed"
   // microseconds spent writing a key.

--- a/include/leveldb/env.h
+++ b/include/leveldb/env.h
@@ -136,7 +136,8 @@ class Env {
       void (*function)(void* arg),
       void* arg,
       int state=0,
-      bool imm_flag=false) = 0;
+      bool imm_flag=false,
+      int priority=0) = 0;
 
   // Start a new thread, invoking "function(arg)" within the new thread.
   // When "function(arg)" returns, the thread will be destroyed.
@@ -160,6 +161,15 @@ class Env {
 
   // Where supported, give count of background jobs pending.
   virtual int GetBackgroundBacklog() const {return(0);};
+
+  // Riak specific call.  Rate is microseconds spent writing
+  // one key.  Usually the average time of many (like 1,000).
+  // Set during background compaction, but not Level-0 write.
+  virtual void SetWriteRate(uint64_t Rate) {};
+
+  // Riak specific call.  Return the current "smoothed"
+  // microseconds spent writing a key.
+  virtual uint64_t GetWriteRate() const {return(0);};
 
  private:
   // No copying allowed


### PR DESCRIPTION
This revision to the throttle is in direct response to the new async eleveldb NIF and removal of +S 64:64 from vm.args.  Those two changes to the erlang environment removed other throttling that erlang was implicitly passing to leveldb.  Also, two edge case bugs were fixed in the old throttle logic which remains.
