### PR TITLE
Making counters 32 bits long on 32 bit platforms

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -1657,7 +1657,7 @@ bool DBImpl::GetProperty(const Slice& property, std::string* value) {
       int index;
 
       index=gPerfCounters->LookupCounter(in.ToString().c_str());
-      snprintf(buf, sizeof(buf), "%u", gPerfCounters->Value(index));
+      snprintf(buf, sizeof(buf), "%" CNTR_FMT, gPerfCounters->Value(index));
       value->append(buf);
       return(true);
   }

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -37,9 +37,6 @@
 #include "util/mutexlock.h"
 #include "leveldb/perf_count.h"
 
-#define __STDC_FORMAT_MACROS
-#include <inttypes.h>
-
 namespace leveldb {
 
 // Information kept for every waiting writer
@@ -1660,7 +1657,7 @@ bool DBImpl::GetProperty(const Slice& property, std::string* value) {
       int index;
 
       index=gPerfCounters->LookupCounter(in.ToString().c_str());
-      snprintf(buf, sizeof(buf), "%" PRIu64 , gPerfCounters->Value(index));
+      snprintf(buf, sizeof(buf), "%u", gPerfCounters->Value(index));
       value->append(buf);
       return(true);
   }

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -37,7 +37,10 @@
 #include "util/mutexlock.h"
 #include "leveldb/perf_count.h"
 
-namespace leveldb {
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
+
+-namespace leveldb {
 
 // Information kept for every waiting writer
 struct DBImpl::Writer {

--- a/include/leveldb/perf_count.h
+++ b/include/leveldb/perf_count.h
@@ -27,6 +27,12 @@
 #include <string>
 #include "leveldb/status.h"
 
+#if defined(__i686) || defined(_WIN32)
+  #define CNTR_FMT "u"
+#else
+  #define CNTR_FMT "llu"
+#endif
+
 namespace leveldb {
 
 // We want 32 bit counters on 32 bit platforms, 64 bit otherwise.

--- a/include/leveldb/perf_count.h
+++ b/include/leveldb/perf_count.h
@@ -29,6 +29,19 @@
 
 namespace leveldb {
 
+// We want 32 bit counters on 32 bit platforms, 64 bit otherwise.
+template<int> struct CounterInfoTpl {
+    typedef uint64_t Type;
+    static const Type MAX_VALUE = Type(-1); 
+};
+
+template<> struct CounterInfoTpl<4> {
+    typedef uint32_t Type;
+    static const Type MAX_VALUE = Type(-1);
+};
+
+typedef CounterInfoTpl<sizeof(void*)> CounterInfo;
+
 enum SstCountEnum
 {
     //
@@ -57,12 +70,14 @@ enum SstCountEnum
 
 class SstCounters
 {
+public:
+    typedef CounterInfo::Type CounterInt;
 protected:
     bool m_IsReadOnly;         //!< set when data decoded from a file
     uint32_t m_Version;        //!< object revision identification
     uint32_t m_CounterSize;    //!< number of objects in m_Counter
 
-    uint64_t m_Counter[eSstCountEnumSize];
+    CounterInt m_Counter[eSstCountEnumSize];
 
 public:
     // constructors / destructor
@@ -75,16 +90,16 @@ public:
     Status DecodeFrom(const Slice& src);
 
     // increment the counter
-    uint64_t Inc(unsigned Index);
+    CounterInt Inc(unsigned Index);
 
     // add value to the counter
-    uint64_t Add(unsigned Index, uint64_t Amount);
+    CounterInt Add(unsigned Index, CounterInt Amount);
 
     // return value of a counter
-    uint64_t Value(unsigned Index) const;
+    CounterInt Value(unsigned Index) const;
 
     // set a value
-    void Set(unsigned Index, uint64_t);
+    void Set(unsigned Index, CounterInt);
 
     // return number of counters
     uint32_t Size() const {return(m_CounterSize);};
@@ -206,16 +221,16 @@ struct PerformanceCounters
 {
 public:
     static int m_LastError;
-
+    typedef CounterInfo::Type CounterInt;
 protected:
     uint32_t m_Version;        //!< object revision identification
     uint32_t m_CounterSize;    //!< number of objects in m_Counter
 
-    volatile uint64_t m_Counter[ePerfCountEnumSize];
+    volatile CounterInt m_Counter[ePerfCountEnumSize];
 
     static const char * m_PerfCounterNames[];
     static int m_PerfSharedId;
-    static volatile uint64_t m_BogusCounter;  //!< for out of range GetPtr calls
+    static volatile CounterInt m_BogusCounter;  //!< for out of range GetPtr calls
 
 public:
     // only called for local object, not for shared memory
@@ -227,19 +242,19 @@ public:
 
     static PerformanceCounters * Init(bool IsReadOnly);
 
-    uint64_t Inc(unsigned Index);
-    uint64_t Dec(unsigned Index);
+    CounterInt Inc(unsigned Index);
+    CounterInt Dec(unsigned Index);
 
     // add value to the counter
-    uint64_t Add(unsigned Index, uint64_t Amount);
+    CounterInt Add(unsigned Index, CounterInt Amount);
 
     // return value of a counter
-    uint64_t Value(unsigned Index) const;
+    CounterInt Value(unsigned Index) const;
 
     // set a value
-    void Set(unsigned Index, uint64_t);
+    void Set(unsigned Index, CounterInt);
 
-    volatile const uint64_t * GetPtr(unsigned Index) const;
+    volatile const CounterInt * GetPtr(unsigned Index) const;
 
     static const char * GetNamePtr(unsigned Index);
 

--- a/include/leveldb/perf_count.h
+++ b/include/leveldb/perf_count.h
@@ -27,7 +27,7 @@
 #include <string>
 #include "leveldb/status.h"
 
-#if defined(__i686) || defined(_WIN32)
+#if INTPTR_MAX == INT32_MAX
   #define CNTR_FMT "u"
 #else
   #define CNTR_FMT "llu"

--- a/util/perf_count.cc
+++ b/util/perf_count.cc
@@ -188,7 +188,7 @@ PerformanceCounters * gPerfCounters(&LocalStartupCounters);
         printf("      m_Version: %u\n", m_Version);
         printf("  m_CounterSize: %u\n", m_CounterSize);
         for (loop=0; loop<m_CounterSize; ++loop)
-            printf("    Counter[%2u]: %u\n", loop, m_Counter[loop]);
+            printf("    Counter[%2u]: %" CNTR_FMT "\n", loop, m_Counter[loop]);
 
         return;
 
@@ -508,7 +508,7 @@ PerformanceCounters * gPerfCounters(&LocalStartupCounters);
 
         for (loop=0; loop<ePerfCountEnumSize; ++loop)
         {
-            printf("  %s: %u\n", m_PerfCounterNames[loop], m_Counter[loop]);
+            printf("  %s: %" CNTR_FMT "\n", m_PerfCounterNames[loop], m_Counter[loop]);
         }   // loop
     };  // Dump
 


### PR DESCRIPTION
@matthewvon this is my proposed change to support compilation on 32 bit platforms. As I understand it after talking to Jon, we're not going crazy supporting everything here. This should at least allow leveldb to compile and pass our test suite.  Let me know what you think.
