### PR TITLE
convert LRUCache from LRU to simple fifo

### DIFF
--- a/util/cache_test.cc
+++ b/util/cache_test.cc
@@ -135,7 +135,7 @@ TEST(CacheTest, EntriesArePinned) {
 TEST(CacheTest, EvictionPolicy) {
   Insert(100, 101);
   Insert(200, 201);
-
+#if 0  // cache switched from lru to fifo ... matthewv Feb 5, 2013
   // Frequently used entry must be kept around
   for (int i = 0; i < kCacheSize + 100; i++) {
     Insert(1000+i, 2000+i);
@@ -144,6 +144,7 @@ TEST(CacheTest, EvictionPolicy) {
   }
   ASSERT_EQ(101, Lookup(100));
   ASSERT_EQ(-1, Lookup(200));
+#endif
 }
 
 TEST(CacheTest, HeavyEntries) {


### PR DESCRIPTION
This is a fast hack to reduce performance problem introduced in 1.2.1 (which actually reduced a performance problem in 1.1).  It is NOT the full change anticipated for 1.4 release.
