### PR TITLE
allow Get() calls to avoid copies into std::string

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -85,6 +85,22 @@ struct DBImpl::CompactionState {
   }
 };
 
+Value::~Value() {}
+
+class StringValue : public Value {
+ public:
+  explicit StringValue(std::string& val) : value_(val) {}
+  ~StringValue() {}
+
+  StringValue& assign(const char* data, size_t size) {
+    value_.assign(data, size);
+    return *this;
+  }
+
+ private:
+  std::string& value_;
+};
+
 // Fix user-supplied options to be reasonable
 template <class T,class V>
 static void ClipToRange(T* ptr, V minvalue, V maxvalue) {
@@ -1280,6 +1296,13 @@ int64_t DBImpl::TEST_MaxNextLevelOverlappingBytes() {
 Status DBImpl::Get(const ReadOptions& options,
                    const Slice& key,
                    std::string* value) {
+  StringValue stringvalue(*value);
+  return DBImpl::Get(options, key, &stringvalue);
+}
+
+Status DBImpl::Get(const ReadOptions& options,
+                   const Slice& key,
+                   Value* value) {
   Status s;
   MutexLock l(&mutex_);
   SequenceNumber snapshot;

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -34,6 +34,9 @@ class DBImpl : public DB {
   virtual Status Get(const ReadOptions& options,
                      const Slice& key,
                      std::string* value);
+  virtual Status Get(const ReadOptions& options,
+                     const Slice& key,
+                     Value* value);
   virtual Iterator* NewIterator(const ReadOptions&);
   virtual const Snapshot* GetSnapshot();
   virtual void ReleaseSnapshot(const Snapshot* snapshot);

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -1685,6 +1685,11 @@ class ModelDB: public DB {
     assert(false);      // Not implemented
     return Status::NotFound(key);
   }
+  virtual Status Get(const ReadOptions& options,
+                     const Slice& key, Value* value) {
+    assert(false);      // Not implemented
+    return Status::NotFound(key);
+  }
   virtual Iterator* NewIterator(const ReadOptions& options) {
     if (options.snapshot == NULL) {
       KVMap* saved = new KVMap;

--- a/db/memtable.cc
+++ b/db/memtable.cc
@@ -105,7 +105,7 @@ void MemTable::Add(SequenceNumber s, ValueType type,
   table_.Insert(buf);
 }
 
-bool MemTable::Get(const LookupKey& key, std::string* value, Status* s) {
+bool MemTable::Get(const LookupKey& key, Value* value, Status* s) {
   Slice memkey = key.memtable_key();
   Table::Iterator iter(&table_);
   iter.Seek(memkey.data());

--- a/db/memtable.h
+++ b/db/memtable.h
@@ -61,7 +61,7 @@ class MemTable {
   // If memtable contains a deletion for key, store a NotFound() error
   // in *status and return true.
   // Else, return false.
-  bool Get(const LookupKey& key, std::string* value, Status* s);
+  bool Get(const LookupKey& key, Value* value, Status* s);
 
  private:
   ~MemTable();  // Private since only Unref() should be used to delete it

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -273,7 +273,7 @@ struct Saver {
   SaverState state;
   const Comparator* ucmp;
   Slice user_key;
-  std::string* value;
+  Value* value;
 };
 }
 static bool SaveValue(void* arg, const Slice& ikey, const Slice& v) {
@@ -300,7 +300,7 @@ static bool NewestFirst(FileMetaData* a, FileMetaData* b) {
 
 Status Version::Get(const ReadOptions& options,
                     const LookupKey& k,
-                    std::string* value,
+                    Value* value,
                     GetStats* stats) {
   Slice ikey = k.internal_key();
   Slice user_key = k.user_key();

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -70,7 +70,7 @@ class Version {
     FileMetaData* seek_file;
     int seek_file_level;
   };
-  Status Get(const ReadOptions&, const LookupKey& key, std::string* val,
+  Status Get(const ReadOptions&, const LookupKey& key, Value* val,
              GetStats* stats);
 
   // Adds "stats" into the current state.  Returns true if a new

--- a/include/leveldb/db.h
+++ b/include/leveldb/db.h
@@ -38,6 +38,17 @@ struct Range {
   Range(const Slice& s, const Slice& l) : start(s), limit(l) { }
 };
 
+// Abstract holder for a DB value.
+// This allows callers to manage their own value buffers and have
+// DB values copied directly into those buffers.
+class Value {
+ public:
+  virtual Value& assign(const char* data, size_t size) = 0;
+
+ protected:
+  virtual ~Value();
+};
+
 // A DB is a persistent ordered map from keys to values.
 // A DB is safe for concurrent access from multiple threads without
 // any external synchronization.
@@ -82,6 +93,8 @@ class DB {
   // May return some other Status on an error.
   virtual Status Get(const ReadOptions& options,
                      const Slice& key, std::string* value) = 0;
+  virtual Status Get(const ReadOptions& options,
+                     const Slice& key, Value* value) = 0;
 
   // Return a heap-allocated iterator over the contents of the database.
   // The result of NewIterator() is initially invalid (caller must


### PR DESCRIPTION
Add a new abstract base class leveldb::Value that applications can easily
derive from to supply their own memory management for values retrieved via
Get(). Add an internal class derived from Value that provides std::string
management to preserve backward compatibility. Overload DBImpl::Get() to
accept a Value_, and to preserve backward compatibility also keep the
original version taking a std::string_.
