### PR TITLE
Add status query for total bytes used by a LevelDB instance

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -1677,6 +1677,18 @@ bool DBImpl::GetProperty(const Slice& property, std::string* value) {
   } else if (in == "sstables") {
     *value = versions_->current()->DebugString();
     return true;
+  } else if (in == "total-bytes") {
+    char buf[50];
+    double total = 0;
+    for (int level = 0; level < config::kNumLevels; level++) {
+      int files = versions_->NumLevelFiles(level);
+      if (stats_[level].micros > 0 || files > 0) {
+        total += versions_->NumLevelBytes(level);
+      }
+    }
+    snprintf(buf, sizeof(buf), "%.0f", total);
+    value->append(buf);
+    return true;
   } else if (-1!=gPerfCounters->LookupCounter(in.ToString().c_str())) {
 
       char buf[66];

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -1679,14 +1679,11 @@ bool DBImpl::GetProperty(const Slice& property, std::string* value) {
     return true;
   } else if (in == "total-bytes") {
     char buf[50];
-    double total = 0;
+    uint64_t total = 0;
     for (int level = 0; level < config::kNumLevels; level++) {
-      int files = versions_->NumLevelFiles(level);
-      if (stats_[level].micros > 0 || files > 0) {
-        total += versions_->NumLevelBytes(level);
-      }
+      total += versions_->NumLevelBytes(level);
     }
-    snprintf(buf, sizeof(buf), "%.0f", total);
+    snprintf(buf, sizeof(buf), "%" PRIu64, total);
     value->append(buf);
     return true;
   } else if (-1!=gPerfCounters->LookupCounter(in.ToString().c_str())) {


### PR DESCRIPTION
This pull-request adds a new LevelDB property "leveldb.total-bytes" that returns the total bytes used by LevelDB for SSTs. This value is equivalent to the sum of the reported per-level sizes shown in the "leveldb.status" output.

---

The main purpose of this change is for use in Riak through the `eleveldb:status` API to allow Riak to estimate the total bytes by a LevelDB vnode. The motivation being the new transfer progress work by @jrwest: basho/platform_tasks#23 
