### PR TITLE
create option flag to control CRC checks during compaction

### DIFF
--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1168,7 +1168,7 @@ void VersionSet::GetRange2(const std::vector<FileMetaData*>& inputs1,
 
 Iterator* VersionSet::MakeInputIterator(Compaction* c) {
   ReadOptions options;
-  options.verify_checksums = options_->paranoid_checks;
+  options.verify_checksums = options_->verify_compactions;
   options.fill_cache = false;
   options.is_compaction = true;
   options.info_log = options_->info_log;

--- a/include/leveldb/options.h
+++ b/include/leveldb/options.h
@@ -61,6 +61,14 @@ struct Options {
   // Default: false
   bool paranoid_checks;
 
+  // Riak specific: this variable replaces paranoid_checks at one
+  // one place in the code.  This variable alone controls whether or not
+  // compaction read operations check CRC values.  Riak needs
+  // the compaction CRC check, but not other paranoid_checks ... so
+  // this independent control.
+  // Default: true
+  bool verify_compactions;
+
   // Use the specified object to interact with the environment,
   // e.g. to read/write files, schedule background work, etc.
   // Default: Env::Default()

--- a/util/options.cc
+++ b/util/options.cc
@@ -16,6 +16,7 @@ Options::Options()
       create_if_missing(false),
       error_if_exists(false),
       paranoid_checks(false),
+      verify_compactions(true),
       env(Env::Default()),
       info_log(NULL),
       write_buffer_size(4<<20),
@@ -37,6 +38,7 @@ Options::Dump(
     Log(log,"     Options.create_if_missing: %d", create_if_missing);
     Log(log,"       Options.error_if_exists: %d", error_if_exists);
     Log(log,"       Options.paranoid_checks: %d", paranoid_checks);
+    Log(log,"    Options.verify_compactions: %d", verify_compactions);
     Log(log,"                   Options.env: %p", env);
     Log(log,"              Options.info_log: %p", info_log);
     Log(log,"     Options.write_buffer_size: %zd", write_buffer_size);


### PR DESCRIPTION
Compaction CRC check was previous enabled via paranoid_checks.  paranoid_checks also enables other tests that we do NOT want enabled.  This new option lets us directly switch on and off the only paranoid_check of current concern.
