### PR TITLE
create new option specifically for compaction CRC test control

### DIFF
--- a/db/c.cc
+++ b/db/c.cc
@@ -416,6 +416,11 @@ void leveldb_options_set_paranoid_checks(
   opt->rep.paranoid_checks = v;
 }
 
+void leveldb_options_set_verify_compactions(
+    leveldb_options_t* opt, unsigned char v) {
+  opt->rep.verify_compactions = v;
+}
+
 void leveldb_options_set_env(leveldb_options_t* opt, leveldb_env_t* env) {
   opt->rep.env = (env ? env->rep : NULL);
 }

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1168,7 +1168,7 @@ void VersionSet::GetRange2(const std::vector<FileMetaData*>& inputs1,
 
 Iterator* VersionSet::MakeInputIterator(Compaction* c) {
   ReadOptions options;
-  options.verify_checksums = options_->paranoid_checks;
+  options.verify_checksums = options_->verify_compactions;
   options.fill_cache = false;
   options.is_compaction = true;
   options.info_log = options_->info_log;

--- a/include/leveldb/c.h
+++ b/include/leveldb/c.h
@@ -192,6 +192,8 @@ extern void leveldb_options_set_error_if_exists(
     leveldb_options_t*, unsigned char);
 extern void leveldb_options_set_paranoid_checks(
     leveldb_options_t*, unsigned char);
+extern void leveldb_options_set_verify_compactions(
+    leveldb_options_t*, unsigned char);
 extern void leveldb_options_set_env(leveldb_options_t*, leveldb_env_t*);
 extern void leveldb_options_set_info_log(leveldb_options_t*, leveldb_logger_t*);
 extern void leveldb_options_set_write_buffer_size(leveldb_options_t*, size_t);

--- a/include/leveldb/options.h
+++ b/include/leveldb/options.h
@@ -61,6 +61,14 @@ struct Options {
   // Default: false
   bool paranoid_checks;
 
+  // Riak specific: this variable replaces paranoid_checks at one
+  // one place in the code.  This variable alone controls whether or not
+  // compaction read operations check CRC values.  Riak needs
+  // the compaction CRC check, but not other paranoid_checks ... so
+  // this independent control.
+  // Default: true
+  bool verify_compactions;
+
   // Use the specified object to interact with the environment,
   // e.g. to read/write files, schedule background work, etc.
   // Default: Env::Default()

--- a/util/options.cc
+++ b/util/options.cc
@@ -16,6 +16,7 @@ Options::Options()
       create_if_missing(false),
       error_if_exists(false),
       paranoid_checks(false),
+      verify_compactions(true),
       env(Env::Default()),
       info_log(NULL),
       write_buffer_size(4<<20),
@@ -37,6 +38,7 @@ Options::Dump(
     Log(log,"     Options.create_if_missing: %d", create_if_missing);
     Log(log,"       Options.error_if_exists: %d", error_if_exists);
     Log(log,"       Options.paranoid_checks: %d", paranoid_checks);
+    Log(log,"    Options.verify_compactions: %d", verify_compactions);
     Log(log,"                   Options.env: %p", env);
     Log(log,"              Options.info_log: %p", info_log);
     Log(log,"     Options.write_buffer_size: %zd", write_buffer_size);


### PR DESCRIPTION
compaction CRC test was previously one of multiple tests controlled by the paranoid_checks option variable.  We do not want all paranoid_checks, only compaction CRC.  This new variable gives us that control.
