### PR TITLE
Mv level work3 ... change from 3 overlapped levels to 2

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -1129,7 +1129,7 @@ Status DBImpl::DoCompactionWork(CompactionState* compact) {
           {
               // raise this compaction's priority if it is blocking a
               //  dire compaction of level 0 files
-              if (config::kL0_SlowdownWritesTrigger < versions_->current()->NumFiles(0))
+              if ((int)config::kL0_SlowdownWritesTrigger < versions_->current()->NumFiles(0))
               {
                   pthread_rwlock_rdlock(&gThreadLock1);
                   is_level0_compaction=true;
@@ -1565,7 +1565,7 @@ Status DBImpl::MakeRoomForWrite(bool force) {
   Status s;
 
   // hint to background compaction.
-  level0_good=(versions_->NumLevelFiles(0) < config::kL0_CompactionTrigger);
+  level0_good=(versions_->NumLevelFiles(0) < (int)config::kL0_CompactionTrigger);
 
   while (true) {
     if (!bg_error_.ok()) {
@@ -1575,7 +1575,7 @@ Status DBImpl::MakeRoomForWrite(bool force) {
       break;
     } else if (
         allow_delay &&
-        versions_->NumLevelFiles(0) >= config::kL0_SlowdownWritesTrigger) {
+        versions_->NumLevelFiles(0) >= (int)config::kL0_SlowdownWritesTrigger) {
       // We are getting close to hitting a hard limit on the number of
       // L0 files.  Rather than delaying a single write by several
       // seconds when we hit the hard limit, start delaying each

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -1126,8 +1126,10 @@ Status DBImpl::DoCompactionWork(CompactionState* compact) {
 
   for (; input->Valid() && !shutting_down_.Acquire_Load(); )
   {
-    // Prioritize immutable compaction work
-    imm_micros+=PrioritizeWork(is_level0_compaction);
+    // Prioritize compaction work ... every 100 keys
+    if (NULL==compact->builder
+	|| 0==(compact->builder->NumEntries() % 100))
+      imm_micros+=PrioritizeWork(is_level0_compaction);
 
     Slice key = input->key();
     if (compact->builder != NULL

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -77,6 +77,11 @@ class DBImpl : public DB {
   // be made to the descriptor are added to *edit.
   Status Recover(VersionEdit* edit);
 
+  // Riak routine:  pause DB::Open if too many compactions
+  //  stacked up immediately.  Happens in some repairs and
+  //  some Riak upgrades
+  void CheckCompactionState();
+
   void MaybeIgnoreError(Status* s) const;
 
   // Delete any unneeded files and stale in-memory entries.

--- a/db/dbformat.h
+++ b/db/dbformat.h
@@ -22,7 +22,7 @@ class Compaction;
 // parameters set via options.
 namespace config {
 static const int kNumLevels = 7;
-static const int kNumOverlapLevels = 3;
+static const int kNumOverlapLevels = 2;
 
 // Level-0 compaction is started when we hit this many files.
 static const size_t kL0_CompactionTrigger = 4;

--- a/db/dbformat.h
+++ b/db/dbformat.h
@@ -31,7 +31,7 @@ static const size_t kL0_CompactionTrigger = 4;
 static const size_t kL0_SlowdownWritesTrigger = 8;
 
 // Maximum number of level-0 files.  We stop writes at this point.
-static const int kL0_StopWritesTrigger = 12;
+static const size_t kL0_StopWritesTrigger = 12;
 
 // Maximum level to which a new compacted memtable is pushed if it
 // does not create overlap.  We try to push to level 2 to avoid the

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -54,12 +54,12 @@ static struct
 // WARNING: m_OverlappedFiles flags need to match config::kNumOverlapFiles ... until unified
 {
     {10485760,  262144000,  57671680,      209715200,             0,  300000000, true},
-    {10485760,  262144000,  57671680,      419430400,             0, 1500000000, true},
-    {10485760,  262144000,  57671680,     4194304000,             0,   31457280, true},
-    {10485760,  125829120,  57671680,     1610612736,      30000000,   41943040, false},
-    {10485760,  147286400,  57671680,    41943040000,   33554432000,   52428800, false},
-    {10485760,  188743680,  57671680,   419430400000,  335544320000,   62914560, false},
-    {10485760,  220200960,  57671680,  4194304000000, 3355443200000,   73400320, false}
+    {10485760,   82914560,  57671680,      419430400,             0,  209715200, true},
+    {10485760,  104371840,  57671680,     1006632960,     200000000,  314572800, false},
+    {10485760,  125829120,  57671680,     4094304000,    3355443200,  419430400, false},
+    {10485760,  147286400,  57671680,    41943040000,   33554432000,  524288000, false},
+    {10485760,  188743680,  57671680,   419430400000,  335544320000,  629145600, false},
+    {10485760,  220200960,  57671680,  4194304000000, 3355443200000,  734003200, false}
 };
 
 
@@ -1087,11 +1087,10 @@ void VersionSet::Finalize(Version* v) {
           {
               int loop, count, value;
 
-              count=(v->files_[level].size() - config::kL0_SlowdownWritesTrigger) +1;
+              count=(v->files_[level].size() - config::kL0_SlowdownWritesTrigger);
 
-              // logarithmic throttle.  8 works against FusionIO, but 7 or 6 should be tested.
-              for (loop=0, value=8; loop<count; ++loop)
-                  value*=8;
+              for (loop=0, value=4; loop<count; ++loop)
+                  value*=2;
 
               penalty+=value;
           }   // else
@@ -1116,9 +1115,9 @@ void VersionSet::Finalize(Version* v) {
 
       // first sort layer needs to clear before next dump of overlapped files.
       else
-          penalty_score = static_cast<double>(level_bytes) / gLevelTraits[level].m_DesiredBytesForLevel;
+          penalty_score = (1<(static_cast<double>(level_bytes) / gLevelTraits[level].m_DesiredBytesForLevel)? 1.0 : 0);
 
-      if (1.0<penalty_score)
+      if (1.0<=penalty_score)
           penalty+=(static_cast<int>(penalty_score));
     }
 

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1167,10 +1167,16 @@ Status VersionSet::WriteSnapshot(log::Writer* log) {
   return log->AddRecord(record);
 }
 
-int VersionSet::NumLevelFiles(int level) const {
+size_t VersionSet::NumLevelFiles(int level) const {
   assert(level >= 0);
   assert(level < config::kNumLevels);
   return current_->files_[level].size();
+}
+
+bool VersionSet::IsLevelOverlapped(int level) const {
+  assert(level >= 0);
+  assert(level < config::kNumLevels);
+  return(gLevelTraits[level].m_OverlappedFiles);
 }
 
 const char* VersionSet::LevelSummary(LevelSummaryStorage* scratch) const {

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1090,7 +1090,7 @@ void VersionSet::Finalize(Version* v) {
               count=(v->files_[level].size() - config::kL0_SlowdownWritesTrigger);
 
               for (loop=0, value=4; loop<count; ++loop)
-                  value*=2;
+                  value*=8;
 
               penalty+=value;
           }   // else

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -194,7 +194,10 @@ class VersionSet {
   }
 
   // Return the number of Table files at the specified level.
-  int NumLevelFiles(int level) const;
+  size_t NumLevelFiles(int level) const;
+
+  // is the specified level overlapped (or if false->sorted)
+  bool IsLevelOverlapped(int level) const;
 
   // Return the combined file size of all files at the specified level.
   int64_t NumLevelBytes(int level) const;


### PR DESCRIPTION
Details here:  https://github.com/basho/leveldb/wiki/Mv-level-work3

Three overlapped levels gives us better performance, especially in write heavy and in read recent heavy environments.  However, the conversion time to shift 1.3 level files into 1.4 formation would have taken hours on big installations.  So only doing one extra overlapped this release.  It will also smooth the way for sorter upgrade from 2 to 3 in a future release.
