### PR TITLE
leveldb's mv-clean-overlaps

### DIFF
--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -813,6 +813,19 @@ VersionSet::VersionSet(const std::string& dbname,
 }
 
 VersionSet::~VersionSet() {
+  // must remove second ref counter that keeps overlapped files locked
+  //  table cache
+
+  for (int level = 0; level < config::kNumLevels; level++) {
+    if (gLevelTraits[level].m_OverlappedFiles)
+    {
+        for (size_t i = 0; i < current_->NumFiles(level); i++) {
+            FileMetaData* f = current_->files_[level][i];
+            table_cache_->Evict(f->number, true);
+        }   // for
+    }   // if
+  } // for
+
   current_->Unref();
   assert(dummy_versions_.next_ == &dummy_versions_);  // List must be empty
   delete descriptor_log_;

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -103,7 +103,7 @@ class Version {
   int PickLevelForMemTableOutput(const Slice& smallest_user_key,
                                  const Slice& largest_user_key);
 
-  int NumFiles(int level) const { return files_[level].size(); }
+  size_t NumFiles(int level) const { return files_[level].size(); }
 
   const std::vector<FileMetaData*> & GetFileList(int level) const {return files_[level];};
 


### PR DESCRIPTION
overlap files do NOT properly clean up memory on database close.

Details here:  https://github.com/basho/leveldb/wiki/Mv-clean-overlaps
