### PR TITLE
1.4.2 turner

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -1627,6 +1627,10 @@ Status DBImpl::MakeRoomForWrite(bool force) {
   bool allow_delay = !force;
   Status s;
 
+  if (force)
+      Log(options_.info_log,
+          "\"force\" parameter passed to MakeRoomForWrite");
+
   // hint to background compaction.
   level0_good=(versions_->NumLevelFiles(0) < (int)config::kL0_CompactionTrigger);
 
@@ -1673,6 +1677,9 @@ Status DBImpl::MakeRoomForWrite(bool force) {
       Log(options_.info_log, "running...\n");
     } else {
       // Attempt to switch to a new memtable and trigger compaction of old
+        Log(options_.info_log, "Level-0 created at %llu with threshold of %llu",
+            (long long unsigned)mem_->ApproximateMemoryUsage(),
+            (long long unsigned)options_.write_buffer_size);
       assert(versions_->PrevLogNumber() == 0);
       uint64_t new_log_number = versions_->NewFileNumber();
       WritableFile* lfile = NULL;

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -63,6 +63,7 @@ class DBImpl : public DB {
   int64_t TEST_MaxNextLevelOverlappingBytes();
 
   void BackgroundImmCompactCall();
+  bool IsCompactionScheduled() {return(bg_compaction_scheduled_ || NULL!=imm_);};
 
  private:
   friend class DB;
@@ -98,7 +99,7 @@ class DBImpl : public DB {
                         VersionEdit* edit,
                         SequenceNumber* max_sequence);
 
-  Status WriteLevel0Table(MemTable* mem, VersionEdit* edit, Version* base);
+  Status WriteLevel0Table(volatile MemTable* mem, VersionEdit* edit, Version* base);
 
   Status MakeRoomForWrite(bool force /* compact even if there is room? */);
   WriteBatch* BuildBatchGroup(Writer** last_writer);
@@ -136,7 +137,7 @@ class DBImpl : public DB {
   port::AtomicPointer shutting_down_;
   port::CondVar bg_cv_;          // Signalled when background work finishes
   MemTable* mem_;
-  MemTable* imm_;                // Memtable being compacted
+  volatile MemTable* imm_;                // Memtable being compacted
   port::AtomicPointer has_imm_;  // So bg thread can detect non-NULL imm_
   WritableFile* logfile_;
   uint64_t logfile_number_;
@@ -163,7 +164,7 @@ class DBImpl : public DB {
     const InternalKey* end;     // NULL means end of key range
     InternalKey tmp_storage;    // Used to keep track of compaction progress
   };
-  ManualCompaction* manual_compaction_;
+  volatile ManualCompaction* manual_compaction_;
 
   VersionSet* versions_;
 

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -62,6 +62,8 @@ class DBImpl : public DB {
   // file at a level >= 1.
   int64_t TEST_MaxNextLevelOverlappingBytes();
 
+  void BackgroundImmCompactCall();
+
  private:
   friend class DB;
   struct CompactionState;

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -64,6 +64,7 @@ class DBImpl : public DB {
 
   void BackgroundImmCompactCall();
   bool IsCompactionScheduled() {return(bg_compaction_scheduled_ || NULL!=imm_);};
+  uint32_t RunningCompactionCount() {return(running_compactions_);};
 
  private:
   friend class DB;
@@ -190,6 +191,7 @@ class DBImpl : public DB {
 
   // hint to background thread when level0 is backing up
   volatile bool level0_good;
+  volatile uint32_t running_compactions_;
 
   // No copying allowed
   DBImpl(const DBImpl&);

--- a/db/memtable.h
+++ b/db/memtable.h
@@ -24,10 +24,10 @@ class MemTable {
   explicit MemTable(const InternalKeyComparator& comparator);
 
   // Increase reference count.
-  void Ref() { ++refs_; }
+  void Ref() volatile { ++refs_; }
 
   // Drop reference count.  Delete if no more references exist.
-  void Unref() {
+  void Unref() volatile {
     --refs_;
     assert(refs_ >= 0);
     if (refs_ <= 0) {

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -430,6 +430,7 @@ Status Version::Get(const ReadOptions& options,
 
 bool Version::UpdateStats(const GetStats& stats) {
   FileMetaData* f = stats.seek_file;
+#if 0
   if (f != NULL) {
     f->allowed_seeks--;
     if (f->allowed_seeks <= 0 && file_to_compact_ == NULL) {
@@ -438,6 +439,7 @@ bool Version::UpdateStats(const GetStats& stats) {
       return true;
     }
   }
+#endif
   return false;
 }
 
@@ -1488,13 +1490,13 @@ void VersionSet::SetupOtherInputs(Compaction* c) {
   {
       // if this is NOT a repair (or panic) situation, take all files
       //  to reduce write amplification
-      if (c->inputs_[0].size()<=config::kL0_StopWritesTrigger 
+      if (c->inputs_[0].size()<=config::kL0_StopWritesTrigger
           && c->inputs_[0].size()!=current_->files_[level].size())
       {
           c->inputs_[0].clear();
           c->inputs_[0].reserve(current_->files_[level].size());
 
-          for (size_t i = 0; i < current_->files_[level].size(); ++i ) 
+          for (size_t i = 0; i < current_->files_[level].size(); ++i )
           {
               FileMetaData* f = current_->files_[level][i];
               c->inputs_[0].push_back(f);

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1482,6 +1482,28 @@ void VersionSet::SetupOtherInputs(Compaction* c) {
                                          &c->grandparents_);
       }
   }   // if
+#if 1
+  // compacting into an overlapped layer
+  else
+  {
+      // if this is NOT a repair (or panic) situation, take all files
+      //  to reduce write amplification
+      if (c->inputs_[0].size()<=config::kL0_StopWritesTrigger 
+          && c->inputs_[0].size()!=current_->files_[level].size())
+      {
+          c->inputs_[0].clear();
+          c->inputs_[0].reserve(current_->files_[level].size());
+
+          for (size_t i = 0; i < current_->files_[level].size(); ++i ) 
+          {
+              FileMetaData* f = current_->files_[level][i];
+              c->inputs_[0].push_back(f);
+          }   // for
+
+          GetRange(c->inputs_[0], &smallest, &largest);
+      }   // if
+  }   // else
+#endif
 
   if (false) {
     Log(options_->info_log, "Compacting %d '%s' .. '%s'",

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -320,6 +320,10 @@ class VersionSet {
   // Either an empty string, or a valid InternalKey.
   std::string compact_pointer_[config::kNumLevels];
 
+  // Riak allows multiple compaction threads, this mutex allows
+  //  only one to write to manifest at a time.  Only used in LogAndApply
+  port::Mutex manifest_mutex_;
+
   // No copying allowed
   VersionSet(const VersionSet&);
   void operator=(const VersionSet&);

--- a/include/leveldb/atomics.h
+++ b/include/leveldb/atomics.h
@@ -1,0 +1,227 @@
+// -------------------------------------------------------------------
+//
+// atomics.h: portable atomic operations for leveldb/eleveldb (http://code.google.com/p/leveldb/)
+//
+// Copyright (c) 2011-2013 Basho Technologies, Inc. All Rights Reserved.
+//
+// This file is provided to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file
+// except in compliance with the License.  You may obtain
+// a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+// -------------------------------------------------------------------
+
+/// Copied from basho/eleveldb/c_src/detail.hpp September 8, 2013
+
+#ifndef LEVELDB_ATOMIC_H
+ #define LEVELDB_ATOMIC_H 1
+
+#include <stdint.h>
+#include <stddef.h>
+
+/* These can be hopefully-replaced with constexpr or compile-time assert later: */
+#if defined(OS_SOLARIS) || defined(SOLARIS) || defined(sun)
+ #define LEVELDB_IS_SOLARIS 1
+#else
+ #undef LEVELDB_IS_SOLARIS
+#endif
+
+#ifdef LEVELDB_IS_SOLARIS
+ #include <atomic.h>
+#endif
+
+namespace leveldb {
+
+/**
+ * Compare and swap
+ */
+
+// primary template
+template <typename PtrT, typename ValueT>
+inline bool compare_and_swap(volatile PtrT *ptr, const ValueT& comp_val, const ValueT& exchange_val);
+
+
+// uint32 size (needed for solaris)
+template <>
+inline bool compare_and_swap(volatile uint32_t *ptr, const int& comp_val, const int& exchange_val)
+{
+#if LEVELDB_IS_SOLARIS
+  return ((uint32_t) comp_val==atomic_cas_32(ptr, comp_val, exchange_val));
+#else
+    return __sync_bool_compare_and_swap(ptr, comp_val, exchange_val);
+#endif
+}
+
+
+// generic specification ... for pointers
+template <typename PtrT, typename ValueT>
+inline bool compare_and_swap(volatile PtrT *ptr, const ValueT& comp_val, const ValueT& exchange_val)
+{
+#if LEVELDB_IS_SOLARIS
+    return (comp_val==atomic_cas_ptr(ptr, comp_val, exchange_val));
+#else
+    return __sync_bool_compare_and_swap(ptr, comp_val, exchange_val);
+#endif
+}
+
+
+/**
+ * Atomic increment
+ */
+
+template <typename ValueT>
+inline ValueT inc_and_fetch(volatile ValueT *ptr);
+
+template <>
+inline uint64_t inc_and_fetch(volatile uint64_t *ptr)
+{
+#if LEVELDB_IS_SOLARIS
+    return atomic_inc_64_nv(ptr);
+#else
+    return __sync_add_and_fetch(ptr, 1);
+#endif
+}
+
+template <>
+inline uint32_t inc_and_fetch(volatile uint32_t *ptr)
+{
+#if LEVELDB_IS_SOLARIS
+    return atomic_inc_32_nv(ptr);
+#else
+    return __sync_add_and_fetch(ptr, 1);
+#endif
+}
+
+#if defined(__APPLE__) || defined(__OpenBSD__) || (defined(__s390__) && !defined(__s390x__))
+template <>
+inline size_t inc_and_fetch(volatile size_t *ptr)
+{
+    return __sync_add_and_fetch(ptr, 1);
+}
+#endif
+
+
+/**
+ * atomic decrement
+ */
+
+template <typename ValueT>
+inline ValueT dec_and_fetch(volatile ValueT *ptr);
+
+template <>
+inline uint64_t dec_and_fetch(volatile uint64_t *ptr)
+{
+#if LEVELDB_IS_SOLARIS
+    return atomic_dec_64_nv(ptr);
+#else
+    return __sync_sub_and_fetch(ptr, 1);
+#endif
+}
+
+template <>
+inline uint32_t dec_and_fetch(volatile uint32_t *ptr)
+{
+#if LEVELDB_IS_SOLARIS
+    return atomic_dec_32_nv(ptr);
+#else
+    return __sync_sub_and_fetch(ptr, 1);
+#endif
+}
+
+#if defined(__APPLE__) || defined(__OpenBSD__) || (defined(__s390__) && !defined(__s390x__))
+template <>
+inline size_t dec_and_fetch(volatile size_t *ptr)
+{
+    return __sync_sub_and_fetch(ptr, 1);
+}
+#endif
+
+
+/**
+ * Atomic add
+ */
+
+
+template <typename ValueT>
+inline ValueT add_and_fetch(volatile ValueT *ptr, ValueT val);
+
+template <>
+inline uint64_t add_and_fetch(volatile uint64_t *ptr, uint64_t val)
+{
+#if LEVELDB_IS_SOLARIS
+    return atomic_add_64_nv(ptr, val);
+#else
+    return __sync_add_and_fetch(ptr, val);
+#endif
+}
+
+template <>
+inline uint32_t add_and_fetch(volatile uint32_t *ptr, uint32_t val)
+{
+#if LEVELDB_IS_SOLARIS
+    return atomic_add_32_nv(ptr, val);
+#else
+    return __sync_add_and_fetch(ptr, val);
+#endif
+}
+
+#if defined(__APPLE__) || defined(__OpenBSD__) || (defined(__s390__) && !defined(__s390x__))
+template <>
+inline size_t add_and_fetch(volatile size_t *ptr, size_t val)
+{
+    return __sync_add_and_fetch(ptr, val);
+}
+#endif
+
+
+/**
+ * Atomic subtract
+ */
+
+template <typename ValueT>
+inline ValueT sub_and_fetch(volatile ValueT *ptr, ValueT val);
+
+template <>
+inline uint64_t sub_and_fetch(volatile uint64_t *ptr, uint64_t val)
+{
+#if LEVELDB_IS_SOLARIS
+    uint64_t temp=(~val)+1;  // 2's complement, bypass sign warnings
+    return atomic_add_64_nv(ptr, temp);
+#else
+    return __sync_sub_and_fetch(ptr, val);
+#endif
+}
+
+template <>
+inline uint32_t sub_and_fetch(volatile uint32_t *ptr, uint32_t val)
+{
+#if LEVELDB_IS_SOLARIS
+    uint32_t temp=(~val)+1;  // 2's complement, bypass sign warnings
+    return atomic_add_32_nv(ptr, temp);
+#else
+    return __sync_sub_and_fetch(ptr, val);
+#endif
+}
+
+#if defined(__APPLE__) || defined(__OpenBSD__) || (defined(__s390__) && !defined(__s390x__))
+template <>
+inline size_t sub_and_fetch(volatile size_t *ptr, size_t val)
+{
+    return __sync_sub_and_fetch(ptr, val);
+}
+#endif
+
+
+
+} // namespace leveldb
+
+#endif

--- a/port/port_posix.cc
+++ b/port/port_posix.cc
@@ -27,6 +27,16 @@ void Mutex::Lock() { PthreadCall("lock", pthread_mutex_lock(&mu_)); }
 
 void Mutex::Unlock() { PthreadCall("unlock", pthread_mutex_unlock(&mu_)); }
 
+#if defined(_POSIX_SPIN_LOCKS) && 0<_POSIX_SPIN_LOCKS
+Spin::Spin() { PthreadCall("init spinlock", pthread_spin_init(&sp_, PTHREAD_PROCESS_PRIVATE)); }
+
+Spin::~Spin() { PthreadCall("destroy spinlock", pthread_spin_destroy(&sp_)); }
+
+void Spin::Lock() { PthreadCall("lock spin", pthread_spin_lock(&sp_)); }
+
+void Spin::Unlock() { PthreadCall("unlock spin", pthread_spin_unlock(&sp_)); }
+#endif
+
 CondVar::CondVar(Mutex* mu)
     : mu_(mu) {
     PthreadCall("init cv", pthread_cond_init(&cv_, NULL));

--- a/port/port_posix.h
+++ b/port/port_posix.h
@@ -102,6 +102,30 @@ class Mutex {
   void operator=(const Mutex&);
 };
 
+
+#if defined(_POSIX_SPIN_LOCKS) && 0<_POSIX_SPIN_LOCKS
+class Spin {
+ public:
+  Spin();
+  ~Spin();
+
+  void Lock();
+  void Unlock();
+  void AssertHeld() { }
+
+ private:
+  friend class CondVar;
+  pthread_spinlock_t sp_;
+
+  // No copying
+  Spin(const Spin&);
+  void operator=(const Spin&);
+};
+#else
+typedef Mutex Spin;
+#endif
+
+
 class CondVar {
  public:
   explicit CondVar(Mutex* mu);

--- a/port/port_posix.h
+++ b/port/port_posix.h
@@ -7,6 +7,9 @@
 #ifndef STORAGE_LEVELDB_PORT_PORT_POSIX_H_
 #define STORAGE_LEVELDB_PORT_PORT_POSIX_H_
 
+// to properly pull in bits/posix_opt.h on Linux
+#include <unistd.h>
+
 #undef PLATFORM_IS_LITTLE_ENDIAN
 #if defined(OS_MACOSX)
   #include <machine/endian.h>

--- a/util/env_posix.cc
+++ b/util/env_posix.cc
@@ -28,9 +28,11 @@
 #include "leveldb/slice.h"
 #include "port/port.h"
 #include "util/crc32c.h"
+#include "util/hot_threads.h"
 #include "util/logging.h"
 #include "util/mutexlock.h"
 #include "util/posix_logger.h"
+#include "util/thread_tasks.h"
 #include "util/throttle.h"
 #include "db/dbformat.h"
 #include "leveldb/perf_count.h"
@@ -1199,6 +1201,8 @@ static void InitDefaultEnv()
 
     PerformanceCounters::Init(false);
 
+    gImmThreads=new HotThreadPool(7, ePerfDebug1, ePerfDebug2,
+                                  ePerfDebug3, ePerfDebug4);
 }
 
 Env* Env::Default() {

--- a/util/hot_threads.cc
+++ b/util/hot_threads.cc
@@ -32,6 +32,10 @@
 
 namespace leveldb {
 
+HotThreadPool * gImmThreads=NULL;
+
+
+
 void *ThreadStaticEntry(void *args)
 {
     HotThread &tdata = *(HotThread *)args;
@@ -82,6 +86,7 @@ HotThread::ThreadRoutine()
         //  then loop to test queue again
         if (NULL!=submission)
         {
+           (*submission)();
 //    basho::async_nif::work_result result = work_item();
 //            HotThreadPool::notify_caller(*submission);
 
@@ -234,7 +239,7 @@ HotThreadPool::FindWaitingThread(
 
 
 bool 
-HotThreadPool::submit(
+HotThreadPool::Submit(
     ThreadTask* item)
 {
     bool ret_flag(false);
@@ -274,6 +279,6 @@ HotThreadPool::submit(
 
     return(ret_flag);
 
-}   // submit
+}   // HotThreadPool::Submit
 
 };  // namespace leveldb

--- a/util/hot_threads.cc
+++ b/util/hot_threads.cc
@@ -1,0 +1,279 @@
+// -------------------------------------------------------------------
+//
+// hot_threads.cc
+//
+// Copyright (c) 2011-2013 Basho Technologies, Inc. All Rights Reserved.
+//
+// This file is provided to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file
+// except in compliance with the License.  You may obtain
+// a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+// HotThread is a subtle variation on the eleveldb_thread_pool.  Both
+//  represent a design pattern that is tested to perform better under
+//  the Erlang VM than other traditional designs.  
+// -------------------------------------------------------------------
+
+#include "leveldb/atomics.h"
+#include "util/hot_threads.h"
+#include "util/thread_tasks.h"
+
+namespace leveldb {
+
+void *ThreadStaticEntry(void *args)
+{
+    HotThread &tdata = *(HotThread *)args;
+
+    return(tdata.ThreadRoutine());
+
+}   // ThreadStaticEntry
+
+
+/**
+ * Worker threads:  worker threads have 3 states:
+ *  A. doing nothing, available to be claimed: m_Available=1
+ *  B. processing work passed by Erlang thread: m_Available=0, m_DirectWork=<non-null>
+ *  C. processing backlog queue of work: m_Available=0, m_DirectWork=NULL
+ */
+void *
+HotThread::ThreadRoutine()
+{
+    ThreadTask * submission;
+
+    submission=NULL;
+
+    while(!m_Pool.m_Shutdown)
+    {
+        // is work assigned yet?
+        //  check backlog work queue if not
+        if (NULL==submission)
+        {
+            // test non-blocking size for hint (much faster)
+            if (0!=m_Pool.m_WorkQueueAtomic)
+            {
+                // retest with locking
+                SpinLock lock(&m_Pool.m_QueueLock);
+
+                if (!m_Pool.m_WorkQueue.empty())
+                {
+                    submission=m_Pool.m_WorkQueue.front();
+                    m_Pool.m_WorkQueue.pop_front();
+                    dec_and_fetch(&m_Pool.m_WorkQueueAtomic);
+                    m_Pool.IncWorkDequeued();
+                    m_Pool.IncWorkWeighted(2);
+                }   // if
+            }   // if
+        }   // if
+
+
+        // a work item identified (direct or queue), work it!
+        //  then loop to test queue again
+        if (NULL!=submission)
+        {
+//    basho::async_nif::work_result result = work_item();
+//            HotThreadPool::notify_caller(*submission);
+
+            // resubmit will increment reference again, so
+            //  always dec even in reuse case
+            submission->RefDec();
+
+            submission=NULL;
+        }   // if
+
+        // no work found, attempt to go into wait state
+        //  (but retest queue before sleep due to race condition)
+        else
+        {
+            MutexLock lock(&m_Mutex);
+
+            m_DirectWork=NULL; // safety
+
+            // only wait if we are really sure no work pending
+            if (0==m_Pool.m_WorkQueueAtomic)
+	    {
+                // yes, thread going to wait. set available now.
+	        m_Available=1;
+                m_Condition.Wait();
+	    }    // if
+
+            m_Available=0;    // safety
+            submission=(ThreadTask *)m_DirectWork; // NULL is valid
+            m_DirectWork=NULL;// safety
+        }   // else
+    }   // while
+
+    return 0;
+
+}   // HotThread::ThreadRoutine
+
+
+HotThreadPool::HotThreadPool(
+    const size_t PoolSize,
+    enum PerformanceCountersEnum Direct,
+    enum PerformanceCountersEnum Queued,
+    enum PerformanceCountersEnum Dequeued,
+    enum PerformanceCountersEnum Weighted)
+    : m_WorkQueueAtomic(0),
+          m_Shutdown(false),
+          m_DirectCounter(Direct), m_QueuedCounter(Queued),
+          m_DequeuedCounter(Dequeued), m_WeightedCounter(Weighted)
+{
+    int ret_val;
+    size_t loop;
+    HotThread * hot_ptr;
+
+    ret_val=0;
+    for (loop=0; loop<PoolSize && 0==ret_val; ++loop)
+    {
+        hot_ptr=new HotThread(*this);
+
+        ret_val=pthread_create(&hot_ptr->m_ThreadId, NULL,  &ThreadStaticEntry, hot_ptr);
+        if (0==ret_val)
+            m_Threads.push_back(hot_ptr);
+        else
+            delete hot_ptr;
+    }   // for
+
+    m_Shutdown=(0!=ret_val);
+
+    return;
+
+}   // HotThreadPool::HotThreadPool
+
+
+HotThreadPool::~HotThreadPool()
+{
+    ThreadPool_t::iterator thread_it;
+    WorkQueue_t::iterator work_it;
+    // set flag
+    m_Shutdown=true;
+
+    // get all threads stopped
+    for (thread_it=m_Threads.begin(); m_Threads.end()!=thread_it; ++thread_it)
+    {
+        {
+            MutexLock lock(&(*thread_it)->m_Mutex);
+            (*thread_it)->m_Condition.SignalAll();
+        }   // lock
+
+        pthread_join((*thread_it)->m_ThreadId, NULL);
+        delete *thread_it;
+    }   // for
+    
+    // release any objects hanging in work queue
+    for (work_it=m_WorkQueue.begin(); m_WorkQueue.end()!=work_it; ++work_it)
+    {
+        (*work_it)->RefDec();
+    }   // for
+
+    return;
+
+}   // HotThreadPool::~HotThreadPool
+
+
+bool                           // returns true if available worker thread found and claimed
+HotThreadPool::FindWaitingThread(
+    ThreadTask * work) // non-NULL to pass current work directly to a thread,
+                               // NULL to potentially nudge an available worker toward backlog queue
+{
+    bool ret_flag;
+    size_t start, index, pool_size;
+
+    ret_flag=false;
+
+    // pick "random" place in thread list.  hopefully
+    //  list size is prime number.
+    pool_size=m_Threads.size();
+    start=(size_t)pthread_self() % pool_size;
+    index=start;
+
+    do
+    {
+        // perform quick test to see thread available
+        if (0!=m_Threads[index]->m_Available && !shutdown_pending())
+        {
+            // perform expensive compare and swap to potentially
+            //  claim worker thread (this is an exclusive claim to the worker)
+            ret_flag = compare_and_swap(&m_Threads[index]->m_Available, 1, 0);
+
+            // the compare/swap only succeeds if worker thread is sitting on
+            //  pthread_cond_wait ... or is about to be there but is holding
+            //  the mutex already
+            if (ret_flag)
+            {
+
+                // man page says mutex lock optional, experience in
+                //  this code says it is not.  using broadcast instead
+                //  of signal to cover one other race condition
+                //  that should never happen with single thread waiting.
+                MutexLock lock(&m_Threads[index]->m_Mutex);
+                m_Threads[index]->m_DirectWork=work;
+                m_Threads[index]->m_Condition.SignalAll();
+            }   // if
+        }   // if
+
+        index=(index+1)%pool_size;
+
+    } while(index!=start && !ret_flag);
+
+    return(ret_flag);
+
+}   // FindWaitingThread
+
+
+bool 
+HotThreadPool::submit(
+    ThreadTask* item)
+{
+    bool ret_flag(false);
+
+    if (NULL!=item)
+    {
+        item->RefInc();
+
+        if(shutdown_pending())
+        {
+            item->RefDec();
+            ret_flag=false;
+        }   // if
+
+        // try to give work to a waiting thread first
+        else if (!FindWaitingThread(item))
+        {
+            // no waiting threads, put on backlog queue
+            {
+                SpinLock lock(&m_QueueLock);
+                inc_and_fetch(&m_WorkQueueAtomic);
+                m_WorkQueue.push_back(item);
+            }
+
+            // to address race condition, thread might be waiting now
+            FindWaitingThread(NULL);
+
+            IncWorkQueued();
+            ret_flag=true;
+        }   // if
+        else
+        {
+            IncWorkDirect();
+            ret_flag=true;
+        }   // else
+    }   // if
+
+    return(ret_flag);
+
+}   // submit
+
+};  // namespace leveldb

--- a/util/hot_threads.h
+++ b/util/hot_threads.h
@@ -1,0 +1,133 @@
+// -------------------------------------------------------------------
+//
+// hot_threads.h
+//
+// Copyright (c) 2011-2013 Basho Technologies, Inc. All Rights Reserved.
+//
+// This file is provided to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file
+// except in compliance with the License.  You may obtain
+// a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+// HotThread is a subtle variation on the eleveldb_thread_pool.  Both
+//  represent a design pattern that is tested to perform better under
+//  the Erlang VM than other traditional designs.  
+// -------------------------------------------------------------------
+
+#ifndef STORAGE_LEVELDB_INCLUDE_HOT_THREADS_H_
+#define STORAGE_LEVELDB_INCLUDE_HOT_THREADS_H_
+
+#include <deque>
+#include <vector>
+
+#include "leveldb/perf_count.h"
+#include "port/port.h"
+#include "util/mutexlock.h"
+
+namespace leveldb
+{
+
+// forward declare
+class ThreadTask;
+
+/**
+ * Meta / managment data related to a worker thread.
+ */
+struct HotThread
+{
+public:
+    pthread_t m_ThreadId;                //!< handle for this thread
+
+    volatile uint32_t m_Available;       //!< 1 if thread waiting, using standard type for atomic operation
+    class HotThreadPool & m_Pool;        //!< parent pool object
+    volatile ThreadTask * m_DirectWork;    //!< work passed direct to thread
+
+    port::Mutex m_Mutex;             //!< mutex for condition variable
+    port::CondVar m_Condition;          //!< condition for thread waiting
+
+public:
+    HotThread(class HotThreadPool & Pool)
+    : m_ThreadId(NULL), m_Available(0), m_Pool(Pool), m_DirectWork(NULL),
+        m_Condition(&m_Mutex)
+    {}   // HotThread
+
+    virtual ~HotThread() {};
+
+    // actual work loop
+    void * ThreadRoutine();
+
+private:
+    HotThread();                              // no default
+    HotThread(const HotThread &);             // no copy
+    HotThread & operator=(const HotThread&);  // no assign
+    
+};  // class HotThread
+
+
+
+class HotThreadPool
+{
+public:
+
+    typedef std::deque<ThreadTask*> WorkQueue_t;
+    typedef std::vector<HotThread *>   ThreadPool_t;
+
+    ThreadPool_t  m_Threads;
+
+    WorkQueue_t   m_WorkQueue;
+    port::Spin m_QueueLock;                    //!< protects access to work_queue
+    volatile size_t m_WorkQueueAtomic;   //!< atomic size to parallel work_queue.size().
+
+    volatile bool m_Shutdown;            //!< should we stop threads and shut down?
+
+    enum PerformanceCountersEnum m_DirectCounter;
+    enum PerformanceCountersEnum m_QueuedCounter;
+    enum PerformanceCountersEnum m_DequeuedCounter;
+    enum PerformanceCountersEnum m_WeightedCounter;
+
+
+public:
+    HotThreadPool(const size_t thread_pool_size,
+                  enum PerformanceCountersEnum Direct,
+                  enum PerformanceCountersEnum Queued,
+                  enum PerformanceCountersEnum Dequeued,
+                  enum PerformanceCountersEnum Weighted);
+    virtual ~HotThreadPool();
+
+    static void *ThreadStart(void *args);
+
+    bool FindWaitingThread(ThreadTask * work);
+
+    bool submit(ThreadTask * item);
+
+    size_t work_queue_size() const { return m_WorkQueue.size();}
+    bool shutdown_pending() const  { return m_Shutdown; }
+    leveldb::PerformanceCounters * perf() const {return(leveldb::gPerfCounters);};
+
+    void IncWorkDirect() {leveldb::gPerfCounters->Inc(m_DirectCounter);};
+    void IncWorkQueued() {leveldb::gPerfCounters->Inc(m_QueuedCounter);};
+    void IncWorkDequeued() {leveldb::gPerfCounters->Inc(m_DequeuedCounter);};
+    void IncWorkWeighted(uint64_t Count) {leveldb::gPerfCounters->Add(m_WeightedCounter, Count);};
+
+private:
+    HotThreadPool(const HotThreadPool &);             // nocopy
+    HotThreadPool& operator=(const HotThreadPool&);  // nocopyassign
+
+};  // class HotThreadPool
+
+} // namespace leveldb
+
+
+#endif  // STORAGE_LEVELDB_INCLUDE_HOT_THREADS_H_

--- a/util/hot_threads.h
+++ b/util/hot_threads.h
@@ -110,7 +110,7 @@ public:
 
     bool FindWaitingThread(ThreadTask * work);
 
-    bool submit(ThreadTask * item);
+    bool Submit(ThreadTask * item);
 
     size_t work_queue_size() const { return m_WorkQueue.size();}
     bool shutdown_pending() const  { return m_Shutdown; }
@@ -126,6 +126,8 @@ private:
     HotThreadPool& operator=(const HotThreadPool&);  // nocopyassign
 
 };  // class HotThreadPool
+
+extern HotThreadPool * gImmThreads;
 
 } // namespace leveldb
 

--- a/util/mutexlock.h
+++ b/util/mutexlock.h
@@ -34,6 +34,21 @@ class MutexLock {
 };
 
 
+class SpinLock {
+ public:
+  explicit SpinLock(port::Spin *sp) : sp_(sp) {
+    this->sp_->Lock();
+  }
+  ~SpinLock() { this->sp_->Unlock(); }
+
+ private:
+  port::Spin *const sp_;
+  // No copying allowed
+  SpinLock(const SpinLock&);
+  void operator=(const SpinLock&);
+};
+
+
 class ReadLock {
  public:
   explicit ReadLock(port::RWMutex *mu) : mu_(mu) {

--- a/util/thread_tasks.h
+++ b/util/thread_tasks.h
@@ -30,6 +30,7 @@
 
 #include <stdint.h>
 
+#include "leveldb/atomics.h"
 #include "db/db_impl.h"
 
 namespace leveldb {

--- a/util/thread_tasks.h
+++ b/util/thread_tasks.h
@@ -1,0 +1,105 @@
+// -------------------------------------------------------------------
+//
+// thread_tasks.h
+//
+// Copyright (c) 2011-2013 Basho Technologies, Inc. All Rights Reserved.
+//
+// This file is provided to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file
+// except in compliance with the License.  You may obtain
+// a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+//  Modeled after eleveldb's workitems.h/.cc
+// -------------------------------------------------------------------
+
+
+#ifndef STORAGE_LEVELDB_INCLUDE_THREAD_TASKS_H_
+#define STORAGE_LEVELDB_INCLUDE_THREAD_TASKS_H_
+
+#include <stdint.h>
+
+#include "db/db_impl.h"
+
+namespace leveldb {
+
+
+/**
+ * Virtual base class for leveldb background tasks
+ */
+class ThreadTask
+{
+public:
+
+protected:
+    volatile uint32_t m_RefCount;
+
+ public:
+    ThreadTask() 
+        : m_RefCount(0) {};
+
+    virtual ~ThreadTask() {};
+
+    uint32_t RefInc() {return(inc_and_fetch(&m_RefCount));};
+
+    uint32_t RefDec()
+    {
+        uint32_t current_refs;
+
+        current_refs=dec_and_fetch(&m_RefCount);
+        if (0==current_refs)
+            delete this;
+        
+        return(current_refs);
+
+    }   // RefObject::RefDec
+
+    // this is the derived object's task routine
+    virtual void operator()()     = 0;
+
+private:
+    ThreadTask(const ThreadTask &);
+    ThreadTask & operator=(const ThreadTask &);
+
+};  // class ThreadTask
+
+
+/**
+ * Background write of imm buffer to Level-0 file
+ */
+
+class ImmWriteTask : public ThreadTask
+{
+protected:
+    DBImpl * m_DBImpl;
+
+public:
+    ImmWriteTask(DBImpl * Db)
+        : m_DBImpl(Db) {};
+
+    virtual ~ImmWriteTask() {};
+
+    virtual void operator()() {m_DBImpl->BackgroundImmCompactCall();};
+
+private:
+    ImmWriteTask();
+    ImmWriteTask(const ImmWriteTask &);
+    ImmWriteTask & operator=(const ImmWriteTask &);
+
+};  // class ImmWriteTask
+
+} // namespace leveldb
+
+
+#endif  // INCL_WORKITEMS_H


### PR DESCRIPTION
1.  fix race condition in close of async recovery log
2.  address performance problems (write speed and level-0 compaction) with big objects

Note:  spin locks taken from earlier PR already approved for Riak 2.0, and hot_threads taken eleveldb async threads of Riak 1.3.
