### PR TITLE
Mv counters update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ TESTS = \
 	filter_block_test \
 	log_test \
 	memenv_test \
+	perf_count_test \
 	skiplist_test \
 	table_test \
 	version_edit_test \
@@ -161,6 +162,9 @@ table_test: table/table_test.o $(LIBOBJECTS) $(TESTHARNESS)
 
 skiplist_test: db/skiplist_test.o $(LIBOBJECTS) $(TESTHARNESS)
 	$(CXX) db/skiplist_test.o $(LIBOBJECTS) $(TESTHARNESS) -o $@ $(LDFLAGS)
+
+perf_count_test: util/perf_count_test.o $(LIBOBJECTS) $(TESTHARNESS)
+	$(CXX) util/perf_count_test.o $(LIBOBJECTS) $(TESTHARNESS) -o $@ $(LDFLAGS)
 
 perf_dump: tools/perf_dump.o $(LIBOBJECTS)
 	$(CXX) tools/perf_dump.o $(LIBOBJECTS) -o $@ $(LDFLAGS)

--- a/include/leveldb/perf_count.h
+++ b/include/leveldb/perf_count.h
@@ -226,6 +226,10 @@ public:
     bool VersionTest()
         {return(ePerfCountEnumSize<=m_CounterSize && ePerfVersion==m_Version);};
 
+    //!< mostly for perf_count_test.cc
+    void SetVersion(uint32_t Version, uint32_t CounterSize)
+    {m_Version=Version; m_CounterSize=CounterSize;};
+
     static PerformanceCounters * Init(bool IsReadOnly);
     static int Close(PerformanceCounters * Counts);
 

--- a/include/leveldb/perf_count.h
+++ b/include/leveldb/perf_count.h
@@ -227,6 +227,7 @@ public:
         {return(ePerfCountEnumSize<=m_CounterSize && ePerfVersion==m_Version);};
 
     static PerformanceCounters * Init(bool IsReadOnly);
+    static int Close(PerformanceCounters * Counts);
 
     uint64_t Inc(unsigned Index);
     uint64_t Dec(unsigned Index);

--- a/util/perf_count.cc
+++ b/util/perf_count.cc
@@ -1,8 +1,8 @@
 // -------------------------------------------------------------------
 //
-// perf_count.cc:  performance counters LevelDB (http://code.google.com/p/leveldb/)
+// perf_count.cc:  performance counters LevelDB
 //
-// Copyright (c) 2012 Basho Technologies, Inc. All Rights Reserved.
+// Copyright (c) 2012-2013 Basho Technologies, Inc. All Rights Reserved.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file
@@ -26,6 +26,7 @@
 #include <sys/shm.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <syslog.h>
 #include <errno.h>
 
 #ifndef STORAGE_LEVELDB_INCLUDE_PERF_COUNT_H_
@@ -205,23 +206,63 @@ PerformanceCounters * gPerfCounters(&LocalStartupCounters);
 
     }   // PerformanceCounters::PerformanceCounters
 
+
     PerformanceCounters *
     PerformanceCounters::Init(
         bool IsReadOnly)
     {
         PerformanceCounters * ret_ptr;
+        bool should_create, good;
+        int ret_val, id;
+        struct shmid_ds shm_info;
 
         ret_ptr=NULL;
+        memset(&shm_info, 0, sizeof(shm_info));
+        good=true;
+
+        // first id attempt, minimal request
+        id=shmget(ePerfKey, 0, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+        if (-1!=id)
+            ret_val=shmctl(id, IPC_STAT, &shm_info);
+        else
+            ret_val=-1;
+
+        // does the shared memory already exists (and of proper size if writing)
+        should_create=(0!=ret_val || ((shm_info.shm_segsz < sizeof(PerformanceCounters)) && !IsReadOnly));
+
+        // should old shared memory be deleted?
+        if (should_create && 0==ret_val)
+        {
+            ret_val=shmctl(id, IPC_RMID, &shm_info);
+            if (0!=ret_val)
+            {
+                syslog(LOG_ERR, "shmctl IPC_RMID failed [%d, %m]", errno);
+                good=false;
+            }   // if
+        }   // if
 
         // attempt to attach/create to shared memory instance
-        m_PerfSharedId=shmget(ePerfKey, sizeof(PerformanceCounters), IPC_CREAT | S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
-        if (-1!=m_PerfSharedId)
+        if (good)
+        {
+            int flags;
+
+            if (IsReadOnly)
+                flags = S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH;
+            else
+                flags = IPC_CREAT | S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH;
+
+            m_PerfSharedId=shmget(ePerfKey, sizeof(PerformanceCounters), flags);
+            good=(-1!=m_PerfSharedId);
+        }   // if
+
+        // map shared memory instance
+        if (good)
         {
             ret_ptr=(PerformanceCounters *)shmat(m_PerfSharedId, NULL, (IsReadOnly ? SHM_RDONLY : 0));
             if ((void*)-1 != ret_ptr)
             {
                 // initialize?
-                if (0==ret_ptr->m_Version || ePerfCountEnumSize!=ret_ptr->m_CounterSize)
+                if (should_create || ePerfVersion!=ret_ptr->m_Version)
                 {
                     if (!IsReadOnly)
                     {
@@ -233,13 +274,18 @@ PerformanceCounters * gPerfCounters(&LocalStartupCounters);
                     // bad version match to existing segment
                     else
                     {
-                        ret_ptr=(PerformanceCounters *)-1;
+                        good=false;
                         errno=EINVAL;
                     }   // else
                 }   // if
             }   // if
+            else
+            {
+                good=false;
+                syslog(LOG_ERR, "shmat failed [%d, %m]", errno);
+            }   // else
 
-            if ((void*)-1 != ret_ptr)
+            if (good)
             {
                 // make this available process wide
                 gPerfCounters=ret_ptr;
@@ -259,6 +305,31 @@ PerformanceCounters * gPerfCounters(&LocalStartupCounters);
         return(ret_ptr);
 
     };  // PerformanceCounters::Init
+
+
+    int
+    PerformanceCounters::Close(
+        PerformanceCounters * Counts)
+    {
+        int ret_val;
+
+        if (NULL!=Counts && &LocalStartupCounters != Counts)
+        {
+            // keep gPerf valid
+            if (gPerfCounters==Counts)
+                gPerfCounters=&LocalStartupCounters;
+
+            ret_val=shmdt(Counts);
+            if (0!=ret_val)
+                ret_val=errno;
+        }   // if
+        else
+        {
+            ret_val=EINVAL;
+        }   // else
+
+        return(ret_val);
+    }   // PerformanceCounters::Close
 
 
     uint64_t

--- a/util/perf_count_test.cc
+++ b/util/perf_count_test.cc
@@ -1,0 +1,154 @@
+// testharness used is 
+// Copyright (c) 2011 The LevelDB Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file. See the AUTHORS file for names of contributors.
+
+// -------------------------------------------------------------------
+//
+// perf_count_test.cc:  unit tests for LevelDB performance counters
+//
+// Copyright (c) 2012-2013 Basho Technologies, Inc. All Rights Reserved.
+//
+// This file is provided to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file
+// except in compliance with the License.  You may obtain
+// a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+// -------------------------------------------------------------------
+
+#include <errno.h>
+#include <sys/ipc.h>
+#include <sys/shm.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+
+#include "leveldb/perf_count.h"
+#include "util/testharness.h"
+
+namespace leveldb {
+
+class PerfTest 
+{
+public:
+    static PerfTest* current_;
+
+    PerfTest()
+    {
+        current_ = this;
+    }
+
+    ~PerfTest() {};
+
+    bool
+    DeleteShm(key_t Key)
+    {
+        int ret_val, id;
+
+        id=shmget(Key, 0, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+        if (-1!=id)
+            ret_val=shmctl(id, IPC_RMID, NULL);
+        else
+            ret_val=-1;
+
+        return(0==ret_val);
+    }
+
+
+    bool
+    CreateShm(key_t Key, size_t Size)
+    {
+        int ret_val;
+
+        ret_val=shmget(Key, Size, IPC_CREAT | S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+        return(-1!=ret_val);
+    }
+
+    size_t
+    GetShmSize(key_t Key)
+    {
+        int ret_val, id;
+        struct shmid_ds shm_info;
+
+        memset(&shm_info, 0, sizeof(shm_info));
+        id=shmget(Key, 0, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+        if (-1!=id)
+        {
+            ret_val=shmctl(id, IPC_STAT, &shm_info);
+
+            if (0!=ret_val)
+                shm_info.shm_segsz=0;
+        }   // if
+        return(shm_info.shm_segsz);
+    }
+
+};  // class PerfTest
+
+
+PerfTest* PerfTest::current_;
+
+
+TEST(PerfTest, CreateNew) 
+{
+    PerformanceCounters * perf_ptr;
+
+    // clear any existing shm
+    DeleteShm(ePerfKey);
+
+    // open for write, will create
+    perf_ptr=PerformanceCounters::Init(false);
+    ASSERT_NE(perf_ptr, (void*)NULL);
+    ASSERT_EQ(sizeof(PerformanceCounters), GetShmSize(ePerfKey));
+
+    // close and reopen for read
+    ASSERT_EQ(0, PerformanceCounters::Close(perf_ptr));
+    
+    perf_ptr=PerformanceCounters::Init(true);
+    ASSERT_NE(perf_ptr, (void*)NULL);
+    ASSERT_EQ(sizeof(PerformanceCounters), GetShmSize(ePerfKey));
+    ASSERT_EQ(0, PerformanceCounters::Close(perf_ptr));
+
+    // cleanup
+    ASSERT_EQ(true, DeleteShm(ePerfKey));
+
+    return;
+
+}   // CreateNew
+
+
+TEST(PerfTest, SizeUpgrade)
+{
+    PerformanceCounters * perf_ptr;
+
+    // clear any existing shm
+    DeleteShm(ePerfKey);
+
+    // Riak 1.2 was 536 bytes
+    ASSERT_NE(536, sizeof(PerformanceCounters));
+    ASSERT_EQ(true, CreateShm(ePerfKey, 536));
+    ASSERT_EQ(536, GetShmSize(ePerfKey));
+
+    // open for write, will recreate to current size
+    perf_ptr=PerformanceCounters::Init(false);
+    ASSERT_NE(perf_ptr, (void*)NULL);
+    ASSERT_EQ(sizeof(PerformanceCounters), GetShmSize(ePerfKey));
+
+    // cleanup
+    ASSERT_EQ(true, DeleteShm(ePerfKey));
+
+    return;
+}   // SizeUpgrade
+
+}  // namespace leveldb
+
+int main(int argc, char** argv) {
+  return leveldb::test::RunAllTests();
+}


### PR DESCRIPTION
This branch updates the performance counters Init() function to properly resize the shared memory as variables get added to the code.  Previously, a user would have to manually "ipcrm" the shared memory segment (or reboot the computer) to have counters work after leveldb upgrade.

perf_count_test was created to validate the changes.  It is now part of the standard "make check" tests.
