### PR TITLE
Mv hot threads1

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -1239,11 +1239,6 @@ Status DBImpl::DoCompactionWork(CompactionState* compact) {
       compact->current_output()->largest.DecodeFrom(key);
       compact->builder->Add(key, input->value());
 
-      // update throttle ... now, end of compaction may be too late
-      //   but not too often since NowMicros can be costly
-      size_t entry_count;
-      entry_count=compact->num_entries + compact->builder->NumEntries();
-
       // Close output file if it is big enough
       if (compact->builder->FileSize() >=
           compact->compaction->MaxOutputFileSize()) {

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -928,6 +928,7 @@ DBImpl::BackgroundImmCompactCall() {
   assert(NULL != imm_);
 
   ++running_compactions_;
+  gPerfCounters->Inc(ePerfBGCompactImm);
 
   if (!shutting_down_.Acquire_Load()) {
     Status s = CompactMemTable();
@@ -1540,7 +1541,7 @@ Status DBImpl::Write(const WriteOptions& options, WriteBatch* my_batch) {
           env_->SleepForMicroseconds(remaining_wait);
           new_end=now+remaining_wait+throttle;
 
-          gPerfCounters->Add(ePerfDebug0, remaining_wait);
+          gPerfCounters->Add(ePerfThrottleWait, remaining_wait);
       }   // if
       else
       {
@@ -1561,7 +1562,7 @@ Status DBImpl::Write(const WriteOptions& options, WriteBatch* my_batch) {
           env_->SleepForMicroseconds(remaining_wait);
           new_end +=remaining_wait;
 
-          gPerfCounters->Add(ePerfDebug0, remaining_wait);
+          gPerfCounters->Add(ePerfThrottleWait, remaining_wait);
       }   // if
 
       throttle_end=new_end;

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -33,8 +33,10 @@
 #include "table/merger.h"
 #include "table/two_level_iterator.h"
 #include "util/coding.h"
+#include "util/hot_threads.h"
 #include "util/logging.h"
 #include "util/mutexlock.h"
+#include "util/thread_tasks.h"
 #include "util/throttle.h"
 #include "leveldb/perf_count.h"
 
@@ -159,7 +161,8 @@ DBImpl::DBImpl(const Options& options, const std::string& dbname)
       bg_compaction_scheduled_(false),
       manual_compaction_(NULL),
       level0_good(true),
-      throttle_end(0)
+      throttle_end(0),
+      running_compactions_(0)
 {
   mem_->Ref();
   has_imm_.Release_Store(NULL);
@@ -178,7 +181,7 @@ DBImpl::~DBImpl() {
   // Wait for background work to finish
   mutex_.Lock();
   shutting_down_.Release_Store(this);  // Any non-NULL value is ok
-  while (bg_compaction_scheduled_) {
+  while (IsCompactionScheduled()) {
     bg_cv_.Wait();
   }
   mutex_.Unlock();
@@ -244,30 +247,36 @@ void DBImpl::MaybeIgnoreError(Status* s) const {
   }
 }
 
-void DBImpl::DeleteObsoleteFiles() {
-  // Make a set of all of the live files
-  std::set<uint64_t> live = pending_outputs_;
-  versions_->AddLiveFiles(&live);
-
-  // prune the database root directory
-  std::vector<std::string> filenames;
-  env_->GetChildren(dbname_, &filenames); // Ignoring errors on purpose
-  for (size_t i = 0; i < filenames.size(); i++) {
-      KeepOrDelete(filenames[i], -1, live);
-  }   // for
-
-  // prune the table file directories
-  for (int level=0; level<config::kNumLevels; ++level)
+void DBImpl::DeleteObsoleteFiles()
+{
+  // Only run this routine when down to one
+  //  simultaneous compaction
+  if (RunningCompactionCount()<2)
   {
-      std::string dirname;
+      // Make a set of all of the live files
+      std::set<uint64_t> live = pending_outputs_;
+      versions_->AddLiveFiles(&live);
 
-      filenames.clear();
-      dirname=MakeDirName2(dbname_, level, "sst");
-      env_->GetChildren(dirname, &filenames); // Ignoring errors on purpose
+      // prune the database root directory
+      std::vector<std::string> filenames;
+      env_->GetChildren(dbname_, &filenames); // Ignoring errors on purpose
       for (size_t i = 0; i < filenames.size(); i++) {
-          KeepOrDelete(filenames[i], level, live);
+          KeepOrDelete(filenames[i], -1, live);
       }   // for
-  }   // for
+
+      // prune the table file directories
+      for (int level=0; level<config::kNumLevels; ++level)
+      {
+          std::string dirname;
+
+          filenames.clear();
+          dirname=MakeDirName2(dbname_, level, "sst");
+          env_->GetChildren(dirname, &filenames); // Ignoring errors on purpose
+          for (size_t i = 0; i < filenames.size(); i++) {
+              KeepOrDelete(filenames[i], level, live);
+          }   // for
+      }   // for
+  }   // if
 }
 
 void
@@ -481,7 +490,7 @@ void DBImpl::CheckCompactionState()
         int level;
 
         // wait out executing compaction (Wait gives mutex to compactions)
-        if (bg_compaction_scheduled_)
+        if (IsCompactionScheduled())
             bg_cv_.Wait();
 
         for (level=0, need_compaction=false;
@@ -501,7 +510,7 @@ void DBImpl::CheckCompactionState()
             }   //if
         }   // for
 
-    } while(bg_compaction_scheduled_ && need_compaction);
+    } while(IsCompactionScheduled() && need_compaction);
 
     if (log_flag)
         Log(options_.info_log, "Cleanup compactions completed ... DB::Open continuing");
@@ -611,7 +620,7 @@ Status DBImpl::RecoverLogFile(uint64_t log_number,
   return status;
 }
 
-Status DBImpl::WriteLevel0Table(MemTable* mem, VersionEdit* edit,
+Status DBImpl::WriteLevel0Table(volatile MemTable* mem, VersionEdit* edit,
                                 Version* base) {
   mutex_.AssertHeld();
   const uint64_t start_micros = env_->NowMicros();
@@ -619,7 +628,7 @@ Status DBImpl::WriteLevel0Table(MemTable* mem, VersionEdit* edit,
   meta.number = versions_->NewFileNumber();
   meta.level = 0;
   pending_outputs_.insert(meta.number);
-  Iterator* iter = mem->NewIterator();
+  Iterator* iter = ((MemTable *)mem)->NewIterator();
   SequenceNumber smallest_snapshot;
   Log(options_.info_log, "Level-0 table #%llu: started",
       (unsigned long long) meta.number);
@@ -777,7 +786,7 @@ void DBImpl::TEST_CompactRange(int level, const Slice* begin,const Slice* end) {
 
   MutexLock l(&mutex_);
   while (!manual.done) {
-    while (manual_compaction_ != NULL || bg_compaction_scheduled_) {
+    while (manual_compaction_ != NULL || IsCompactionScheduled()) {
       bg_cv_.Wait();
     }
     manual_compaction_ = &manual;
@@ -815,31 +824,22 @@ void DBImpl::MaybeScheduleCompaction() {
   priority=0;
   push=false;
 
-  // writing of memory to disk: high priority
-  if (NULL!=imm_)
+  // merge level 0s to level 1
+  Compaction * c_ptr;
+  c_ptr=versions_->PickCompaction();
+
+  // compaction of level 0 files:  high priority
+  if (NULL!=c_ptr && c_ptr->level()==0)
   {
       push=true;
+      priority=versions_->NumLevelFiles(0);
   }   // if
-
-  // merge level 0s to level 1
   else
   {
-      Compaction * c_ptr;
-      c_ptr=versions_->PickCompaction();
+      priority=versions_->current()->WritePenalty();
+  }   // else
 
-      // compaction of level 0 files:  high priority
-      if (NULL!=c_ptr && c_ptr->level()==0)
-      {
-          push=true;
-          priority=versions_->NumLevelFiles(0);
-      }   // if
-      else
-      {
-          priority=versions_->current()->WritePenalty();
-      }   // else
-
-      delete c_ptr;
-  }   // if
+  delete c_ptr;
 
   if (push)
   {
@@ -850,13 +850,11 @@ void DBImpl::MaybeScheduleCompaction() {
           state=1;
   }   // if
 
-
   if (bg_compaction_scheduled_ && !push) {
     // Already scheduled
   } else if (shutting_down_.Acquire_Load()) {
     // DB is being deleted; no more background compactions
-  } else if (imm_ == NULL &&
-             manual_compaction_ == NULL &&
+  } else if (manual_compaction_ == NULL &&
              !versions_->NeedsCompaction()) {
     // No work to be done
   } else {
@@ -872,6 +870,9 @@ void DBImpl::BGWork(void* db) {
 void DBImpl::BackgroundCall() {
   MutexLock l(&mutex_);
   assert(bg_compaction_scheduled_);
+
+  ++running_compactions_;
+
   if (!shutting_down_.Acquire_Load()) {
     Status s = BackgroundCompaction();
     if (!s.ok()) {
@@ -888,31 +889,71 @@ void DBImpl::BackgroundCall() {
     }
   }
   bg_compaction_scheduled_ = false;
+  --running_compactions_;
 
   // Previous compaction may have produced too many files in a level,
   // so reschedule another compaction if needed.
   if (!options_.is_repair)
       MaybeScheduleCompaction();
   bg_cv_.SignalAll();
+
 }
+
+
+void
+DBImpl::BackgroundImmCompactCall() {
+  MutexLock l(&mutex_);
+  assert(NULL != imm_);
+
+  ++running_compactions_;
+
+  if (!shutting_down_.Acquire_Load()) {
+    Status s = CompactMemTable();
+    if (!s.ok()) {
+      // Wait a little bit before retrying background compaction in
+      // case this is an environmental problem and we do not want to
+      // chew up resources for failed compactions for the duration of
+      // the problem.
+      bg_cv_.SignalAll();  // In case a waiter can proceed despite the error
+      Log(options_.info_log, "Waiting after background imm compaction error: %s",
+          s.ToString().c_str());
+      mutex_.Unlock();
+      env_->SleepForMicroseconds(1000000);
+      mutex_.Lock();
+    }
+  }
+//  IsCompactionScheduled() = false;
+  --running_compactions_;
+
+  // Previous compaction may have produced too many files in a level,
+  // so reschedule another compaction if needed.
+  if (!options_.is_repair)
+      MaybeScheduleCompaction();
+
+  // shutdown is waiting for this imm_ to clear
+  if (shutting_down_.Acquire_Load()) {
+
+    // must abandon data in memory ... hope recovery log works
+    imm_->Unref();
+    imm_ = NULL;
+    has_imm_.Release_Store(NULL);
+  } // if
+
+  bg_cv_.SignalAll();
+}
+
+
 
 Status DBImpl::BackgroundCompaction() {
   Status status;
 
   mutex_.AssertHeld();
 
-  if (imm_ != NULL) {
-    pthread_rwlock_rdlock(&gThreadLock0);
-    status=CompactMemTable();
-    pthread_rwlock_unlock(&gThreadLock0);
-    return status;
-  }
-
   Compaction* c;
   bool is_manual = (manual_compaction_ != NULL);
   InternalKey manual_end;
   if (is_manual) {
-    ManualCompaction* m = manual_compaction_;
+    ManualCompaction* m = (ManualCompaction *) manual_compaction_;
     c = versions_->CompactRange(m->level, m->begin, m->end);
     m->done = (c == NULL);
     if (c != NULL) {
@@ -979,7 +1020,7 @@ Status DBImpl::BackgroundCompaction() {
   }
 
   if (is_manual) {
-    ManualCompaction* m = manual_compaction_;
+    ManualCompaction* m = (ManualCompaction *)manual_compaction_;
     if (!status.ok()) {
       m->done = true;
     }
@@ -1134,9 +1175,6 @@ Status DBImpl::DoCompactionWork(CompactionState* compact) {
 
   bool is_level0_compaction=(0 == compact->compaction->level());
 
-  if (is_level0_compaction)
-      pthread_rwlock_rdlock(&gThreadLock1);
-
   const uint64_t start_micros = env_->NowMicros();
   int64_t imm_micros = 0;  // Micros spent doing imm_ compactions
 
@@ -1151,11 +1189,6 @@ Status DBImpl::DoCompactionWork(CompactionState* compact) {
 
   for (; input->Valid() && !shutting_down_.Acquire_Load(); )
   {
-    // Prioritize compaction work ... every 100 keys
-    if (NULL==compact->builder
-	|| 0==(compact->builder->NumEntries() % 100))
-      imm_micros+=PrioritizeWork(is_level0_compaction);
-
     Slice key = input->key();
     if (compact->builder != NULL
         && compact->compaction->ShouldStopBefore(key, compact->builder->NumEntries())) {
@@ -1187,22 +1220,6 @@ Status DBImpl::DoCompactionWork(CompactionState* compact) {
       //   but not too often since NowMicros can be costly
       size_t entry_count;
       entry_count=compact->num_entries + compact->builder->NumEntries();
-
-      // every so often see if priority needs to change
-      if (1==(entry_count % 1000) && 1000<entry_count)
-      {
-          // test for priority change
-          if (!is_level0_compaction)
-          {
-              // raise this compaction's priority if it is blocking a
-              //  dire compaction of level 0 files
-              if ((int)config::kL0_SlowdownWritesTrigger < versions_->current()->NumFiles(0))
-              {
-                  pthread_rwlock_rdlock(&gThreadLock1);
-                  is_level0_compaction=true;
-              }   // if
-          }   // if
-      }   // if
 
       // Close output file if it is big enough
       if (compact->builder->FileSize() >=
@@ -1250,9 +1267,6 @@ Status DBImpl::DoCompactionWork(CompactionState* compact) {
     stats.bytes_written += compact->outputs[i].file_size;
   }
 
-  if (is_level0_compaction)
-      pthread_rwlock_unlock(&gThreadLock1);
-
   mutex_.Lock();
   stats_[compact->compaction->level() + 1].Add(stats);
 
@@ -1269,94 +1283,12 @@ Status DBImpl::DoCompactionWork(CompactionState* compact) {
 }
 
 
-int64_t
-DBImpl::PrioritizeWork(
-    bool IsLevel0)
-{
-    int64_t start_time;
-    bool again;
-    int ret_val;
-    struct timespec timeout;
-
-    start_time=env_->NowMicros();
-
-    // loop while on hold due to higher priority stuff,
-    //  but keep polling for need to handle imm_
-    do
-    {
-        again=false;
-
-        if (has_imm_.NoBarrier_Load() != NULL) {
-            mutex_.Lock();
-            if (imm_ != NULL) {
-                if (IsLevel0)
-                    pthread_rwlock_unlock(&gThreadLock1);
-                pthread_rwlock_rdlock(&gThreadLock0);
-                CompactMemTable();
-                pthread_rwlock_unlock(&gThreadLock0);
-                if (IsLevel0)
-                    pthread_rwlock_rdlock(&gThreadLock1);
-                bg_cv_.SignalAll();  // Wakeup MakeRoomForWrite() if necessary
-            }   // if
-            mutex_.Unlock();
-        }   // if
-
-        // pause to potentially hand off disk to
-        //  memtable threads
-#if defined(_POSIX_TIMEOUTS) && (_POSIX_TIMEOUTS - 200112L) >= 0L
-        clock_gettime(CLOCK_REALTIME, &timeout);
-        timeout.tv_sec+=1;
-        ret_val=pthread_rwlock_timedwrlock(&gThreadLock0, &timeout);
-#else
-        // ugly spin lock
-        ret_val=pthread_rwlock_trywrlock(&gThreadLock0);
-        if (EBUSY==ret_val)
-        {
-            ret_val=ETIMEDOUT;
-            env_->SleepForMicroseconds(10000);  // 10milliseconds
-        }   // if
-#endif
-        if (0==ret_val)
-            pthread_rwlock_unlock(&gThreadLock0);
-        again=(ETIMEDOUT==ret_val);
-
-        // Give priorities to level 0 compactions, unless
-        //  this compaction is blocking a level 0 in this database
-        if (!IsLevel0 && level0_good && !again)
-        {
-#if defined(_POSIX_TIMEOUTS) && (_POSIX_TIMEOUTS - 200112L) >= 0L
-            clock_gettime(CLOCK_REALTIME, &timeout);
-            timeout.tv_sec+=1;
-            ret_val=pthread_rwlock_timedwrlock(&gThreadLock1, &timeout);
-#else
-            // ugly spin lock
-            ret_val=pthread_rwlock_trywrlock(&gThreadLock1);
-            if (EBUSY==ret_val)
-            {
-                ret_val=ETIMEDOUT;
-                env_->SleepForMicroseconds(10000);  // 10milliseconds
-            }   // if
-#endif
-
-            if (0==ret_val)
-                pthread_rwlock_unlock(&gThreadLock1);
-            again=again || (ETIMEDOUT==ret_val);
-        }   // if
-    } while(again);
-
-    // let caller know how long was spent waiting.
-    return(env_->NowMicros() - start_time);
-
-}  // PrioritizeWork
-
-
-
 namespace {
 struct IterState {
   port::Mutex* mu;
   Version* version;
   MemTable* mem;
-  MemTable* imm;
+  volatile MemTable* imm;
 };
 
 static void CleanupIteratorState(void* arg1, void* arg2) {
@@ -1381,7 +1313,7 @@ Iterator* DBImpl::NewInternalIterator(const ReadOptions& options,
   list.push_back(mem_->NewIterator());
   mem_->Ref();
   if (imm_ != NULL) {
-    list.push_back(imm_->NewIterator());
+     list.push_back(((MemTable *)imm_)->NewIterator());
     imm_->Ref();
   }
   versions_->current()->AddIterators(options, &list);
@@ -1429,7 +1361,7 @@ Status DBImpl::Get(const ReadOptions& options,
   }
 
   MemTable* mem = mem_;
-  MemTable* imm = imm_;
+  volatile MemTable* imm = imm_;
   Version* current = versions_->current();
   mem->Ref();
   if (imm != NULL) imm->Ref();
@@ -1446,7 +1378,7 @@ Status DBImpl::Get(const ReadOptions& options,
     if (mem->Get(lkey, value, &s)) {
       // Done
         gPerfCounters->Inc(ePerfGetMem);
-    } else if (imm != NULL && imm->Get(lkey, value, &s)) {
+    } else if (imm != NULL && ((MemTable *)imm)->Get(lkey, value, &s)) {
       // Done
         gPerfCounters->Inc(ePerfGetImm);
     } else {
@@ -1568,7 +1500,7 @@ Status DBImpl::Write(const WriteOptions& options, WriteBatch* my_batch) {
   gPerfCounters->Inc(ePerfApiWrite);
 
   // protect use of versions_ ... still within scope of mutex_ lock
-  throttle=versions_->WriteThrottleUsec(bg_compaction_scheduled_);
+  throttle=versions_->WriteThrottleUsec(IsCompactionScheduled());
   }  // release  MutexLock l(&mutex_)
 
 
@@ -1747,7 +1679,12 @@ Status DBImpl::MakeRoomForWrite(bool force) {
       logfile_number_ = new_log_number;
       log_ = new log::Writer(lfile);
       imm_ = mem_;
-      has_imm_.Release_Store(imm_);
+      has_imm_.Release_Store((MemTable*)imm_);
+      if (NULL!=imm_)
+      {
+         ThreadTask * task=new ImmWriteTask(this);
+         gImmThreads->Submit(task);
+      }
       mem_ = new MemTable(internal_comparator_);
       mem_->Ref();
       force = false;   // Do not force another compaction if have room

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -1238,11 +1238,6 @@ Status DBImpl::DoCompactionWork(CompactionState* compact) {
       compact->current_output()->largest.DecodeFrom(key);
       compact->builder->Add(key, input->value());
 
-      // update throttle ... now, end of compaction may be too late
-      //   but not too often since NowMicros can be costly
-      size_t entry_count;
-      entry_count=compact->num_entries + compact->builder->NumEntries();
-
       // Close output file if it is big enough
       if (compact->builder->FileSize() >=
           compact->compaction->MaxOutputFileSize()) {

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -35,8 +35,10 @@
 #include "util/db_list.h"
 #include "util/coding.h"
 #include "util/flexcache.h"
+#include "util/hot_threads.h"
 #include "util/logging.h"
 #include "util/mutexlock.h"
+#include "util/thread_tasks.h"
 #include "util/throttle.h"
 #include "leveldb/perf_count.h"
 
@@ -173,7 +175,8 @@ DBImpl::DBImpl(const Options& options, const std::string& dbname)
       bg_compaction_scheduled_(false),
       manual_compaction_(NULL),
       level0_good(true),
-      throttle_end(0)
+      throttle_end(0),
+      running_compactions_(0)
 {
   DBList()->AddDB(this, options_.is_internal_db);
 
@@ -199,7 +202,7 @@ DBImpl::~DBImpl() {
   // Wait for background work to finish
   mutex_.Lock();
   shutting_down_.Release_Store(this);  // Any non-NULL value is ok
-  while (bg_compaction_scheduled_) {
+  while (IsCompactionScheduled()) {
     bg_cv_.Wait();
   }
   mutex_.Unlock();
@@ -266,30 +269,36 @@ void DBImpl::MaybeIgnoreError(Status* s) const {
   }
 }
 
-void DBImpl::DeleteObsoleteFiles() {
-  // Make a set of all of the live files
-  std::set<uint64_t> live = pending_outputs_;
-  versions_->AddLiveFiles(&live);
-
-  // prune the database root directory
-  std::vector<std::string> filenames;
-  env_->GetChildren(dbname_, &filenames); // Ignoring errors on purpose
-  for (size_t i = 0; i < filenames.size(); i++) {
-      KeepOrDelete(filenames[i], -1, live);
-  }   // for
-
-  // prune the table file directories
-  for (int level=0; level<config::kNumLevels; ++level)
+void DBImpl::DeleteObsoleteFiles()
+{
+  // Only run this routine when down to one
+  //  simultaneous compaction
+  if (RunningCompactionCount()<2)
   {
-      std::string dirname;
+      // Make a set of all of the live files
+      std::set<uint64_t> live = pending_outputs_;
+      versions_->AddLiveFiles(&live);
 
-      filenames.clear();
-      dirname=MakeDirName2(dbname_, level, "sst");
-      env_->GetChildren(dirname, &filenames); // Ignoring errors on purpose
+      // prune the database root directory
+      std::vector<std::string> filenames;
+      env_->GetChildren(dbname_, &filenames); // Ignoring errors on purpose
       for (size_t i = 0; i < filenames.size(); i++) {
-          KeepOrDelete(filenames[i], level, live);
+          KeepOrDelete(filenames[i], -1, live);
       }   // for
-  }   // for
+
+      // prune the table file directories
+      for (int level=0; level<config::kNumLevels; ++level)
+      {
+          std::string dirname;
+
+          filenames.clear();
+          dirname=MakeDirName2(dbname_, level, "sst");
+          env_->GetChildren(dirname, &filenames); // Ignoring errors on purpose
+          for (size_t i = 0; i < filenames.size(); i++) {
+              KeepOrDelete(filenames[i], level, live);
+          }   // for
+      }   // for
+  }   // if
 }
 
 void
@@ -503,7 +512,7 @@ void DBImpl::CheckCompactionState()
         int level;
 
         // wait out executing compaction (Wait gives mutex to compactions)
-        if (bg_compaction_scheduled_)
+        if (IsCompactionScheduled())
             bg_cv_.Wait();
 
         for (level=0, need_compaction=false;
@@ -523,7 +532,7 @@ void DBImpl::CheckCompactionState()
             }   //if
         }   // for
 
-    } while(bg_compaction_scheduled_ && need_compaction);
+    } while(IsCompactionScheduled() && need_compaction);
 
     if (log_flag)
         Log(options_.info_log, "Cleanup compactions completed ... DB::Open continuing");
@@ -633,7 +642,7 @@ Status DBImpl::RecoverLogFile(uint64_t log_number,
   return status;
 }
 
-Status DBImpl::WriteLevel0Table(MemTable* mem, VersionEdit* edit,
+Status DBImpl::WriteLevel0Table(volatile MemTable* mem, VersionEdit* edit,
                                 Version* base) {
   mutex_.AssertHeld();
   const uint64_t start_micros = env_->NowMicros();
@@ -641,7 +650,7 @@ Status DBImpl::WriteLevel0Table(MemTable* mem, VersionEdit* edit,
   meta.number = versions_->NewFileNumber();
   meta.level = 0;
   pending_outputs_.insert(meta.number);
-  Iterator* iter = mem->NewIterator();
+  Iterator* iter = ((MemTable *)mem)->NewIterator();
   SequenceNumber smallest_snapshot;
   Log(options_.info_log, "Level-0 table #%llu: started",
       (unsigned long long) meta.number);
@@ -799,7 +808,7 @@ void DBImpl::TEST_CompactRange(int level, const Slice* begin,const Slice* end) {
 
   MutexLock l(&mutex_);
   while (!manual.done) {
-    while (manual_compaction_ != NULL || bg_compaction_scheduled_) {
+    while (manual_compaction_ != NULL || IsCompactionScheduled()) {
       bg_cv_.Wait();
     }
     manual_compaction_ = &manual;
@@ -837,31 +846,22 @@ void DBImpl::MaybeScheduleCompaction() {
   priority=0;
   push=false;
 
-  // writing of memory to disk: high priority
-  if (NULL!=imm_)
+  // merge level 0s to level 1
+  Compaction * c_ptr;
+  c_ptr=versions_->PickCompaction();
+
+  // compaction of level 0 files:  high priority
+  if (NULL!=c_ptr && c_ptr->level()==0)
   {
       push=true;
+      priority=versions_->NumLevelFiles(0);
   }   // if
-
-  // merge level 0s to level 1
   else
   {
-      Compaction * c_ptr;
-      c_ptr=versions_->PickCompaction();
+      priority=versions_->current()->WritePenalty();
+  }   // else
 
-      // compaction of level 0 files:  high priority
-      if (NULL!=c_ptr && c_ptr->level()==0)
-      {
-          push=true;
-          priority=versions_->NumLevelFiles(0);
-      }   // if
-      else
-      {
-          priority=versions_->current()->WritePenalty();
-      }   // else
-
-      delete c_ptr;
-  }   // if
+  delete c_ptr;
 
   if (push)
   {
@@ -872,13 +872,11 @@ void DBImpl::MaybeScheduleCompaction() {
           state=1;
   }   // if
 
-
   if (bg_compaction_scheduled_ && !push) {
     // Already scheduled
   } else if (shutting_down_.Acquire_Load()) {
     // DB is being deleted; no more background compactions
-  } else if (imm_ == NULL &&
-             manual_compaction_ == NULL &&
+  } else if (manual_compaction_ == NULL &&
              !versions_->NeedsCompaction()) {
     // No work to be done
   } else {
@@ -894,6 +892,9 @@ void DBImpl::BGWork(void* db) {
 void DBImpl::BackgroundCall() {
   MutexLock l(&mutex_);
   assert(bg_compaction_scheduled_);
+
+  ++running_compactions_;
+
   if (!shutting_down_.Acquire_Load()) {
     Status s = BackgroundCompaction();
     if (!s.ok()) {
@@ -910,31 +911,71 @@ void DBImpl::BackgroundCall() {
     }
   }
   bg_compaction_scheduled_ = false;
+  --running_compactions_;
 
   // Previous compaction may have produced too many files in a level,
   // so reschedule another compaction if needed.
   if (!options_.is_repair)
       MaybeScheduleCompaction();
   bg_cv_.SignalAll();
+
 }
+
+
+void
+DBImpl::BackgroundImmCompactCall() {
+  MutexLock l(&mutex_);
+  assert(NULL != imm_);
+
+  ++running_compactions_;
+
+  if (!shutting_down_.Acquire_Load()) {
+    Status s = CompactMemTable();
+    if (!s.ok()) {
+      // Wait a little bit before retrying background compaction in
+      // case this is an environmental problem and we do not want to
+      // chew up resources for failed compactions for the duration of
+      // the problem.
+      bg_cv_.SignalAll();  // In case a waiter can proceed despite the error
+      Log(options_.info_log, "Waiting after background imm compaction error: %s",
+          s.ToString().c_str());
+      mutex_.Unlock();
+      env_->SleepForMicroseconds(1000000);
+      mutex_.Lock();
+    }
+  }
+//  IsCompactionScheduled() = false;
+  --running_compactions_;
+
+  // Previous compaction may have produced too many files in a level,
+  // so reschedule another compaction if needed.
+  if (!options_.is_repair)
+      MaybeScheduleCompaction();
+
+  // shutdown is waiting for this imm_ to clear
+  if (shutting_down_.Acquire_Load()) {
+
+    // must abandon data in memory ... hope recovery log works
+    imm_->Unref();
+    imm_ = NULL;
+    has_imm_.Release_Store(NULL);
+  } // if
+
+  bg_cv_.SignalAll();
+}
+
+
 
 Status DBImpl::BackgroundCompaction() {
   Status status;
 
   mutex_.AssertHeld();
 
-  if (imm_ != NULL) {
-    pthread_rwlock_rdlock(&gThreadLock0);
-    status=CompactMemTable();
-    pthread_rwlock_unlock(&gThreadLock0);
-    return status;
-  }
-
   Compaction* c;
   bool is_manual = (manual_compaction_ != NULL);
   InternalKey manual_end;
   if (is_manual) {
-    ManualCompaction* m = manual_compaction_;
+    ManualCompaction* m = (ManualCompaction *) manual_compaction_;
     c = versions_->CompactRange(m->level, m->begin, m->end);
     m->done = (c == NULL);
     if (c != NULL) {
@@ -1001,7 +1042,7 @@ Status DBImpl::BackgroundCompaction() {
   }
 
   if (is_manual) {
-    ManualCompaction* m = manual_compaction_;
+    ManualCompaction* m = (ManualCompaction *)manual_compaction_;
     if (!status.ok()) {
       m->done = true;
     }
@@ -1156,9 +1197,6 @@ Status DBImpl::DoCompactionWork(CompactionState* compact) {
 
   bool is_level0_compaction=(0 == compact->compaction->level());
 
-  if (is_level0_compaction)
-      pthread_rwlock_rdlock(&gThreadLock1);
-
   const uint64_t start_micros = env_->NowMicros();
   int64_t imm_micros = 0;  // Micros spent doing imm_ compactions
 
@@ -1173,11 +1211,6 @@ Status DBImpl::DoCompactionWork(CompactionState* compact) {
 
   for (; input->Valid() && !shutting_down_.Acquire_Load(); )
   {
-    // Prioritize compaction work ... every 100 keys
-    if (NULL==compact->builder
-	|| 0==(compact->builder->NumEntries() % 100))
-      imm_micros+=PrioritizeWork(is_level0_compaction);
-
     Slice key = input->key();
     if (compact->builder != NULL
         && compact->compaction->ShouldStopBefore(key, compact->builder->NumEntries())) {
@@ -1209,22 +1242,6 @@ Status DBImpl::DoCompactionWork(CompactionState* compact) {
       //   but not too often since NowMicros can be costly
       size_t entry_count;
       entry_count=compact->num_entries + compact->builder->NumEntries();
-
-      // every so often see if priority needs to change
-      if (1==(entry_count % 1000) && 1000<entry_count)
-      {
-          // test for priority change
-          if (!is_level0_compaction)
-          {
-              // raise this compaction's priority if it is blocking a
-              //  dire compaction of level 0 files
-              if ((int)config::kL0_SlowdownWritesTrigger < versions_->current()->NumFiles(0))
-              {
-                  pthread_rwlock_rdlock(&gThreadLock1);
-                  is_level0_compaction=true;
-              }   // if
-          }   // if
-      }   // if
 
       // Close output file if it is big enough
       if (compact->builder->FileSize() >=
@@ -1272,9 +1289,6 @@ Status DBImpl::DoCompactionWork(CompactionState* compact) {
     stats.bytes_written += compact->outputs[i].file_size;
   }
 
-  if (is_level0_compaction)
-      pthread_rwlock_unlock(&gThreadLock1);
-
   mutex_.Lock();
   stats_[compact->compaction->level() + 1].Add(stats);
 
@@ -1291,94 +1305,12 @@ Status DBImpl::DoCompactionWork(CompactionState* compact) {
 }
 
 
-int64_t
-DBImpl::PrioritizeWork(
-    bool IsLevel0)
-{
-    int64_t start_time;
-    bool again;
-    int ret_val;
-    struct timespec timeout;
-
-    start_time=env_->NowMicros();
-
-    // loop while on hold due to higher priority stuff,
-    //  but keep polling for need to handle imm_
-    do
-    {
-        again=false;
-
-        if (has_imm_.NoBarrier_Load() != NULL) {
-            mutex_.Lock();
-            if (imm_ != NULL) {
-                if (IsLevel0)
-                    pthread_rwlock_unlock(&gThreadLock1);
-                pthread_rwlock_rdlock(&gThreadLock0);
-                CompactMemTable();
-                pthread_rwlock_unlock(&gThreadLock0);
-                if (IsLevel0)
-                    pthread_rwlock_rdlock(&gThreadLock1);
-                bg_cv_.SignalAll();  // Wakeup MakeRoomForWrite() if necessary
-            }   // if
-            mutex_.Unlock();
-        }   // if
-
-        // pause to potentially hand off disk to
-        //  memtable threads
-#if defined(_POSIX_TIMEOUTS) && (_POSIX_TIMEOUTS - 200112L) >= 0L
-        clock_gettime(CLOCK_REALTIME, &timeout);
-        timeout.tv_sec+=1;
-        ret_val=pthread_rwlock_timedwrlock(&gThreadLock0, &timeout);
-#else
-        // ugly spin lock
-        ret_val=pthread_rwlock_trywrlock(&gThreadLock0);
-        if (EBUSY==ret_val)
-        {
-            ret_val=ETIMEDOUT;
-            env_->SleepForMicroseconds(10000);  // 10milliseconds
-        }   // if
-#endif
-        if (0==ret_val)
-            pthread_rwlock_unlock(&gThreadLock0);
-        again=(ETIMEDOUT==ret_val);
-
-        // Give priorities to level 0 compactions, unless
-        //  this compaction is blocking a level 0 in this database
-        if (!IsLevel0 && level0_good && !again)
-        {
-#if defined(_POSIX_TIMEOUTS) && (_POSIX_TIMEOUTS - 200112L) >= 0L
-            clock_gettime(CLOCK_REALTIME, &timeout);
-            timeout.tv_sec+=1;
-            ret_val=pthread_rwlock_timedwrlock(&gThreadLock1, &timeout);
-#else
-            // ugly spin lock
-            ret_val=pthread_rwlock_trywrlock(&gThreadLock1);
-            if (EBUSY==ret_val)
-            {
-                ret_val=ETIMEDOUT;
-                env_->SleepForMicroseconds(10000);  // 10milliseconds
-            }   // if
-#endif
-
-            if (0==ret_val)
-                pthread_rwlock_unlock(&gThreadLock1);
-            again=again || (ETIMEDOUT==ret_val);
-        }   // if
-    } while(again);
-
-    // let caller know how long was spent waiting.
-    return(env_->NowMicros() - start_time);
-
-}  // PrioritizeWork
-
-
-
 namespace {
 struct IterState {
   port::Mutex* mu;
   Version* version;
   MemTable* mem;
-  MemTable* imm;
+  volatile MemTable* imm;
 };
 
 static void CleanupIteratorState(void* arg1, void* arg2) {
@@ -1403,7 +1335,7 @@ Iterator* DBImpl::NewInternalIterator(const ReadOptions& options,
   list.push_back(mem_->NewIterator());
   mem_->Ref();
   if (imm_ != NULL) {
-    list.push_back(imm_->NewIterator());
+     list.push_back(((MemTable *)imm_)->NewIterator());
     imm_->Ref();
   }
   versions_->current()->AddIterators(options, &list);
@@ -1451,7 +1383,7 @@ Status DBImpl::Get(const ReadOptions& options,
   }
 
   MemTable* mem = mem_;
-  MemTable* imm = imm_;
+  volatile MemTable* imm = imm_;
   Version* current = versions_->current();
   mem->Ref();
   if (imm != NULL) imm->Ref();
@@ -1468,7 +1400,7 @@ Status DBImpl::Get(const ReadOptions& options,
     if (mem->Get(lkey, value, &s)) {
       // Done
         gPerfCounters->Inc(ePerfGetMem);
-    } else if (imm != NULL && imm->Get(lkey, value, &s)) {
+    } else if (imm != NULL && ((MemTable *)imm)->Get(lkey, value, &s)) {
       // Done
         gPerfCounters->Inc(ePerfGetImm);
     } else {
@@ -1590,7 +1522,7 @@ Status DBImpl::Write(const WriteOptions& options, WriteBatch* my_batch) {
   gPerfCounters->Inc(ePerfApiWrite);
 
   // protect use of versions_ ... still within scope of mutex_ lock
-  throttle=versions_->WriteThrottleUsec(bg_compaction_scheduled_);
+  throttle=versions_->WriteThrottleUsec(IsCompactionScheduled());
   }  // release  MutexLock l(&mutex_)
 
 
@@ -1769,7 +1701,12 @@ Status DBImpl::MakeRoomForWrite(bool force) {
       logfile_number_ = new_log_number;
       log_ = new log::Writer(lfile);
       imm_ = mem_;
-      has_imm_.Release_Store(imm_);
+      has_imm_.Release_Store((MemTable*)imm_);
+      if (NULL!=imm_)
+      {
+         ThreadTask * task=new ImmWriteTask(this);
+         gImmThreads->Submit(task);
+      }
       mem_ = new MemTable(internal_comparator_);
       mem_->Ref();
       force = false;   // Do not force another compaction if have room

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -62,6 +62,10 @@ class DBImpl : public DB {
   // file at a level >= 1.
   int64_t TEST_MaxNextLevelOverlappingBytes();
 
+  void BackgroundImmCompactCall();
+  bool IsCompactionScheduled() {mutex_.AssertHeld(); return(bg_compaction_scheduled_ || NULL!=imm_);};
+  uint32_t RunningCompactionCount() {mutex_.AssertHeld(); return(running_compactions_);};
+
  private:
   friend class DB;
   struct CompactionState;
@@ -96,7 +100,7 @@ class DBImpl : public DB {
                         VersionEdit* edit,
                         SequenceNumber* max_sequence);
 
-  Status WriteLevel0Table(MemTable* mem, VersionEdit* edit, Version* base);
+  Status WriteLevel0Table(volatile MemTable* mem, VersionEdit* edit, Version* base);
 
   Status MakeRoomForWrite(bool force /* compact even if there is room? */);
   WriteBatch* BuildBatchGroup(Writer** last_writer);
@@ -134,7 +138,7 @@ class DBImpl : public DB {
   port::AtomicPointer shutting_down_;
   port::CondVar bg_cv_;          // Signalled when background work finishes
   MemTable* mem_;
-  MemTable* imm_;                // Memtable being compacted
+  volatile MemTable* imm_;                // Memtable being compacted
   port::AtomicPointer has_imm_;  // So bg thread can detect non-NULL imm_
   WritableFile* logfile_;
   uint64_t logfile_number_;
@@ -161,7 +165,7 @@ class DBImpl : public DB {
     const InternalKey* end;     // NULL means end of key range
     InternalKey tmp_storage;    // Used to keep track of compaction progress
   };
-  ManualCompaction* manual_compaction_;
+  volatile ManualCompaction* manual_compaction_;
 
   VersionSet* versions_;
 
@@ -189,6 +193,7 @@ class DBImpl : public DB {
   volatile bool level0_good;
 
   volatile uint64_t throttle_end;
+  volatile uint32_t running_compactions_;
 
   // No copying allowed
   DBImpl(const DBImpl&);

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -67,6 +67,10 @@ class DBImpl : public DB {
   size_t GetCacheCapacity() {return(double_cache.GetCapacity(false));}
   void PurgeExpiredFileCache() {double_cache.PurgeExpiredFiles();};
 
+  void BackgroundImmCompactCall();
+  bool IsCompactionScheduled() {mutex_.AssertHeld(); return(bg_compaction_scheduled_ || NULL!=imm_);};
+  uint32_t RunningCompactionCount() {mutex_.AssertHeld(); return(running_compactions_);};
+
  private:
   friend class DB;
   struct CompactionState;
@@ -101,7 +105,7 @@ class DBImpl : public DB {
                         VersionEdit* edit,
                         SequenceNumber* max_sequence);
 
-  Status WriteLevel0Table(MemTable* mem, VersionEdit* edit, Version* base);
+  Status WriteLevel0Table(volatile MemTable* mem, VersionEdit* edit, Version* base);
 
   Status MakeRoomForWrite(bool force /* compact even if there is room? */);
   WriteBatch* BuildBatchGroup(Writer** last_writer);
@@ -144,7 +148,7 @@ class DBImpl : public DB {
 
   port::CondVar bg_cv_;          // Signalled when background work finishes
   MemTable* mem_;
-  MemTable* imm_;                // Memtable being compacted
+  volatile MemTable* imm_;                // Memtable being compacted
   port::AtomicPointer has_imm_;  // So bg thread can detect non-NULL imm_
   WritableFile* logfile_;
   uint64_t logfile_number_;
@@ -171,7 +175,7 @@ class DBImpl : public DB {
     const InternalKey* end;     // NULL means end of key range
     InternalKey tmp_storage;    // Used to keep track of compaction progress
   };
-  ManualCompaction* manual_compaction_;
+  volatile ManualCompaction* manual_compaction_;
 
   VersionSet* versions_;
 
@@ -199,6 +203,7 @@ class DBImpl : public DB {
   volatile bool level0_good;
 
   volatile uint64_t throttle_end;
+  volatile uint32_t running_compactions_;
 
 
   // accessor to new, dynamic block_cache

--- a/db/memtable.h
+++ b/db/memtable.h
@@ -24,10 +24,10 @@ class MemTable {
   explicit MemTable(const InternalKeyComparator& comparator);
 
   // Increase reference count.
-  void Ref() { ++refs_; }
+  void Ref() volatile { ++refs_; }
 
   // Drop reference count.  Delete if no more references exist.
-  void Unref() {
+  void Unref() volatile {
     --refs_;
     assert(refs_ >= 0);
     if (refs_ <= 0) {

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -434,8 +434,8 @@ Status Version::Get(const ReadOptions& options,
 }
 
 bool Version::UpdateStats(const GetStats& stats) {
-  FileMetaData* f = stats.seek_file;
 #if 0
+  FileMetaData* f = stats.seek_file;
   if (f != NULL) {
     f->allowed_seeks--;
     if (f->allowed_seeks <= 0 && file_to_compact_ == NULL) {

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -17,6 +17,7 @@
 #include "table/two_level_iterator.h"
 #include "util/coding.h"
 #include "util/logging.h"
+#include "util/mutexlock.h"
 #include "leveldb/perf_count.h"
 
 namespace leveldb {
@@ -53,16 +54,16 @@ static struct
 
 // WARNING: m_OverlappedFiles flags need to match config::kNumOverlapFiles ... until unified
 {
-    {10485760,  262144000,  57671680,      209715200,             0,  300000000, true},
-    {10485760,   82914560,  57671680,      419430400,             0,  209715200, true},
-    {10485760,  104371840,  57671680,     1006632960,     200000000,  314572800, false},
-    {10485760,  125829120,  57671680,     4094304000,    3355443200,  419430400, false},
+    {10485760,  262144000,  57671680,      209715200,                0,     300000000, true},
+    {10485760,   82914560,  57671680,      419430400,                0,     209715200, true},
+    {10485760,  104371840,  57671680,     1006632960,        200000000,     314572800, false},
+    {10485760,  125829120,  57671680,     4094304000ULL,    3355443200ULL,  419430400, false},
     {10485760,  147286400,  57671680,    41943040000ULL,   33554432000ULL,  524288000, false},
     {10485760,  188743680,  57671680,   419430400000ULL,  335544320000ULL,  629145600, false},
     {10485760,  220200960,  57671680,  4194304000000ULL, 3355443200000ULL,  734003200, false}
 };
 
-
+/// ULL above needed to compile on OSX 10.7.3
 
 static int64_t TotalFileSize(const std::vector<FileMetaData*>& files) {
   int64_t sum = 0;
@@ -434,6 +435,7 @@ Status Version::Get(const ReadOptions& options,
 
 bool Version::UpdateStats(const GetStats& stats) {
   FileMetaData* f = stats.seek_file;
+#if 0
   if (f != NULL) {
     f->allowed_seeks--;
     if (f->allowed_seeks <= 0 && file_to_compact_ == NULL) {
@@ -442,6 +444,7 @@ bool Version::UpdateStats(const GetStats& stats) {
       return true;
     }
   }
+#endif
   return false;
 }
 
@@ -884,35 +887,47 @@ Status VersionSet::LogAndApply(VersionEdit* edit, port::Mutex* mu) {
     }
   }
 
-  // Unlock during expensive MANIFEST log write
-  {
-    mu->Unlock();
-
-    // Write new record to MANIFEST log
-    if (s.ok()) {
-      std::string record;
-      edit->EncodeTo(&record);
-      s = descriptor_log_->AddRecord(record);
-      if (s.ok()) {
-        s = descriptor_file_->Sync();
-      }
-    }
-
-    // If we just created a new descriptor file, install it by writing a
-    // new CURRENT file that points to it.
-    if (s.ok() && !new_manifest_file.empty()) {
-      s = SetCurrentFile(env_, dbname_, manifest_file_number_);
-    }
-
-    mu->Lock();
-  }
-
   // Install the new version
+  //  matthewv Oct 2013 - this used to be after the MANIFEST write
+  //  but overlapping compactions allow for a file to get lost
+  //  if first does not post to version completely.
   if (s.ok()) {
     AppendVersion(v);
     log_number_ = edit->log_number_;
     prev_log_number_ = edit->prev_log_number_;
-  } else {
+  }
+
+  // Unlock during expensive MANIFEST log write
+  {
+    mu->Unlock();
+
+    // but only one writer at a time
+    {
+        MutexLock lock(&manifest_mutex_);
+        // Write new record to MANIFEST log
+        if (s.ok()) {
+            std::string record;
+            edit->EncodeTo(&record);
+            s = descriptor_log_->AddRecord(record);
+            if (s.ok()) {
+                s = descriptor_file_->Sync();
+            }
+        }
+
+        // If we just created a new descriptor file, install it by writing a
+        // new CURRENT file that points to it.
+        if (s.ok() && !new_manifest_file.empty()) {
+            s = SetCurrentFile(env_, dbname_, manifest_file_number_);
+        }
+    }   // manifest_lock_
+
+    mu->Lock();
+  }
+
+  // this used to be "else" clause to if(s.ok)
+  //  moved on Oct 2013
+  if (!s.ok())
+  {
     delete v;
     if (!new_manifest_file.empty()) {
       delete descriptor_log_;
@@ -1478,6 +1493,28 @@ void VersionSet::SetupOtherInputs(Compaction* c) {
                                          &c->grandparents_);
       }
   }   // if
+#if 1
+  // compacting into an overlapped layer
+  else
+  {
+      // if this is NOT a repair (or panic) situation, take all files
+      //  to reduce write amplification
+      if (c->inputs_[0].size()<=config::kL0_StopWritesTrigger
+          && c->inputs_[0].size()!=current_->files_[level].size())
+      {
+          c->inputs_[0].clear();
+          c->inputs_[0].reserve(current_->files_[level].size());
+
+          for (size_t i = 0; i < current_->files_[level].size(); ++i )
+          {
+              FileMetaData* f = current_->files_[level][i];
+              c->inputs_[0].push_back(f);
+          }   // for
+
+          GetRange(c->inputs_[0], &smallest, &largest);
+      }   // if
+  }   // else
+#endif
 
   if (false) {
     Log(options_->info_log, "Compacting %d '%s' .. '%s'",

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -322,6 +322,10 @@ class VersionSet {
   // Either an empty string, or a valid InternalKey.
   std::string compact_pointer_[config::kNumLevels];
 
+  // Riak allows multiple compaction threads, this mutex allows
+  //  only one to write to manifest at a time.  Only used in LogAndApply
+  port::Mutex manifest_mutex_;
+
   // No copying allowed
   VersionSet(const VersionSet&);
   void operator=(const VersionSet&);

--- a/include/leveldb/atomics.h
+++ b/include/leveldb/atomics.h
@@ -1,0 +1,227 @@
+// -------------------------------------------------------------------
+//
+// atomics.h: portable atomic operations for leveldb/eleveldb (http://code.google.com/p/leveldb/)
+//
+// Copyright (c) 2011-2013 Basho Technologies, Inc. All Rights Reserved.
+//
+// This file is provided to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file
+// except in compliance with the License.  You may obtain
+// a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+// -------------------------------------------------------------------
+
+/// Copied from basho/eleveldb/c_src/detail.hpp September 8, 2013
+
+#ifndef LEVELDB_ATOMIC_H
+ #define LEVELDB_ATOMIC_H 1
+
+#include <stdint.h>
+#include <stddef.h>
+
+/* These can be hopefully-replaced with constexpr or compile-time assert later: */
+#if defined(OS_SOLARIS) || defined(SOLARIS) || defined(sun)
+ #define LEVELDB_IS_SOLARIS 1
+#else
+ #undef LEVELDB_IS_SOLARIS
+#endif
+
+#ifdef LEVELDB_IS_SOLARIS
+ #include <atomic.h>
+#endif
+
+namespace leveldb {
+
+/**
+ * Compare and swap
+ */
+
+// primary template
+template <typename PtrT, typename ValueT>
+inline bool compare_and_swap(volatile PtrT *ptr, const ValueT& comp_val, const ValueT& exchange_val);
+
+
+// uint32 size (needed for solaris)
+template <>
+inline bool compare_and_swap(volatile uint32_t *ptr, const int& comp_val, const int& exchange_val)
+{
+#if LEVELDB_IS_SOLARIS
+  return ((uint32_t) comp_val==atomic_cas_32(ptr, comp_val, exchange_val));
+#else
+    return __sync_bool_compare_and_swap(ptr, comp_val, exchange_val);
+#endif
+}
+
+
+// generic specification ... for pointers
+template <typename PtrT, typename ValueT>
+inline bool compare_and_swap(volatile PtrT *ptr, const ValueT& comp_val, const ValueT& exchange_val)
+{
+#if LEVELDB_IS_SOLARIS
+    return (comp_val==atomic_cas_ptr(ptr, comp_val, exchange_val));
+#else
+    return __sync_bool_compare_and_swap(ptr, comp_val, exchange_val);
+#endif
+}
+
+
+/**
+ * Atomic increment
+ */
+
+template <typename ValueT>
+inline ValueT inc_and_fetch(volatile ValueT *ptr);
+
+template <>
+inline uint64_t inc_and_fetch(volatile uint64_t *ptr)
+{
+#if LEVELDB_IS_SOLARIS
+    return atomic_inc_64_nv(ptr);
+#else
+    return __sync_add_and_fetch(ptr, 1);
+#endif
+}
+
+template <>
+inline uint32_t inc_and_fetch(volatile uint32_t *ptr)
+{
+#if LEVELDB_IS_SOLARIS
+    return atomic_inc_32_nv(ptr);
+#else
+    return __sync_add_and_fetch(ptr, 1);
+#endif
+}
+
+#if defined(__APPLE__) || defined(__OpenBSD__) || (defined(__s390__) && !defined(__s390x__))
+template <>
+inline size_t inc_and_fetch(volatile size_t *ptr)
+{
+    return __sync_add_and_fetch(ptr, 1);
+}
+#endif
+
+
+/**
+ * atomic decrement
+ */
+
+template <typename ValueT>
+inline ValueT dec_and_fetch(volatile ValueT *ptr);
+
+template <>
+inline uint64_t dec_and_fetch(volatile uint64_t *ptr)
+{
+#if LEVELDB_IS_SOLARIS
+    return atomic_dec_64_nv(ptr);
+#else
+    return __sync_sub_and_fetch(ptr, 1);
+#endif
+}
+
+template <>
+inline uint32_t dec_and_fetch(volatile uint32_t *ptr)
+{
+#if LEVELDB_IS_SOLARIS
+    return atomic_dec_32_nv(ptr);
+#else
+    return __sync_sub_and_fetch(ptr, 1);
+#endif
+}
+
+#if defined(__APPLE__) || defined(__OpenBSD__) || (defined(__s390__) && !defined(__s390x__))
+template <>
+inline size_t dec_and_fetch(volatile size_t *ptr)
+{
+    return __sync_sub_and_fetch(ptr, 1);
+}
+#endif
+
+
+/**
+ * Atomic add
+ */
+
+
+template <typename ValueT>
+inline ValueT add_and_fetch(volatile ValueT *ptr, ValueT val);
+
+template <>
+inline uint64_t add_and_fetch(volatile uint64_t *ptr, uint64_t val)
+{
+#if LEVELDB_IS_SOLARIS
+    return atomic_add_64_nv(ptr, val);
+#else
+    return __sync_add_and_fetch(ptr, val);
+#endif
+}
+
+template <>
+inline uint32_t add_and_fetch(volatile uint32_t *ptr, uint32_t val)
+{
+#if LEVELDB_IS_SOLARIS
+    return atomic_add_32_nv(ptr, val);
+#else
+    return __sync_add_and_fetch(ptr, val);
+#endif
+}
+
+#if defined(__APPLE__) || defined(__OpenBSD__) || (defined(__s390__) && !defined(__s390x__))
+template <>
+inline size_t add_and_fetch(volatile size_t *ptr, size_t val)
+{
+    return __sync_add_and_fetch(ptr, val);
+}
+#endif
+
+
+/**
+ * Atomic subtract
+ */
+
+template <typename ValueT>
+inline ValueT sub_and_fetch(volatile ValueT *ptr, ValueT val);
+
+template <>
+inline uint64_t sub_and_fetch(volatile uint64_t *ptr, uint64_t val)
+{
+#if LEVELDB_IS_SOLARIS
+    uint64_t temp=(~val)+1;  // 2's complement, bypass sign warnings
+    return atomic_add_64_nv(ptr, temp);
+#else
+    return __sync_sub_and_fetch(ptr, val);
+#endif
+}
+
+template <>
+inline uint32_t sub_and_fetch(volatile uint32_t *ptr, uint32_t val)
+{
+#if LEVELDB_IS_SOLARIS
+    uint32_t temp=(~val)+1;  // 2's complement, bypass sign warnings
+    return atomic_add_32_nv(ptr, temp);
+#else
+    return __sync_sub_and_fetch(ptr, val);
+#endif
+}
+
+#if defined(__APPLE__) || defined(__OpenBSD__) || (defined(__s390__) && !defined(__s390x__))
+template <>
+inline size_t sub_and_fetch(volatile size_t *ptr, size_t val)
+{
+    return __sync_sub_and_fetch(ptr, val);
+}
+#endif
+
+
+
+} // namespace leveldb
+
+#endif

--- a/include/leveldb/perf_count.h
+++ b/include/leveldb/perf_count.h
@@ -191,7 +191,8 @@ enum PerformanceCountersEnum
 
     ePerfBGWriteError=66,   //!< error in write/close, see syslog
 
-    ePerfThrottleWait=67,      //!< milliseconds of throttle wait
+    ePerfThrottleWait=67,   //!< milliseconds of throttle wait
+    ePerfThreadError=68,    //!< system error on thread related call, no LOG access
 
     // must follow last index name to represent size of array
     //  (ASSUMES previous enum is highest value)

--- a/include/leveldb/perf_count.h
+++ b/include/leveldb/perf_count.h
@@ -191,6 +191,8 @@ enum PerformanceCountersEnum
 
     ePerfBGWriteError=66,   //!< error in write/close, see syslog
 
+    ePerfThrottleWait=67,      //!< milliseconds of throttle wait
+
     // must follow last index name to represent size of array
     //  (ASSUMES previous enum is highest value)
     ePerfCountEnumSize,     //!< size of the array described by the enum values

--- a/port/port_posix.h
+++ b/port/port_posix.h
@@ -7,6 +7,9 @@
 #ifndef STORAGE_LEVELDB_PORT_PORT_POSIX_H_
 #define STORAGE_LEVELDB_PORT_PORT_POSIX_H_
 
+// to properly pull in bits/posix_opt.h on Linux
+#include <unistd.h>
+
 #undef PLATFORM_IS_LITTLE_ENDIAN
 #if defined(OS_MACOSX)
   #include <machine/endian.h>

--- a/util/cache2.cc
+++ b/util/cache2.cc
@@ -418,11 +418,9 @@ DoubleCache::DoubleCache(
     const Options & options)
     : m_FileCache(NULL), m_BlockCache(NULL),
       m_IsInternalDB(options.is_internal_db),
+      m_Overhead(0), m_TotalAllocation(0),
       m_FileTimeout(4*24*60*60)  // default is 4 days
 {
-    // build two new caches
-    Flush();
-
     // fixed allocation for recovery log and info LOG: 20M each
     //  (with 64 or open databases, this is a serious number)
     // and fixed allocation for two write buffers
@@ -433,6 +431,9 @@ DoubleCache::DoubleCache(
         m_TotalAllocation -= m_Overhead;
     else
         m_TotalAllocation=0;
+
+    // build two new caches
+    Flush();
 
 }   // DoubleCache::DoubleCache
 

--- a/util/db_list.cc
+++ b/util/db_list.cc
@@ -63,6 +63,7 @@ DBListShutdown()
 
 
 DBListImpl::DBListImpl()
+    : m_UserDBCount(0), m_InternalDBCount(0)
 {
 }   // DBListImpl::DBListImpl
 

--- a/util/env_posix.cc
+++ b/util/env_posix.cc
@@ -28,9 +28,11 @@
 #include "port/port.h"
 #include "util/crc32c.h"
 #include "util/db_list.h"
+#include "util/hot_threads.h"
 #include "util/logging.h"
 #include "util/mutexlock.h"
 #include "util/posix_logger.h"
+#include "util/thread_tasks.h"
 #include "util/throttle.h"
 #include "db/dbformat.h"
 #include "leveldb/perf_count.h"
@@ -1129,6 +1131,7 @@ pthread_t PosixEnv::StartThread(void (*function)(void* arg), void* arg) {
   return(t);
 }
 
+
 // this was a reference file:  unmap, purge page cache, close
 void BGFileCloser(void * arg)
 {
@@ -1361,6 +1364,9 @@ static void InitDefaultEnv()
         crc32c::SwitchToHardwareCRC();
 
     PerformanceCounters::Init(false);
+
+    gImmThreads=new HotThreadPool(7, ePerfDebug1, ePerfDebug2,
+                                  ePerfDebug3, ePerfDebug4);
     started=true;
 }
 
@@ -1389,6 +1395,9 @@ void Env::Shutdown()
 
     ComparatorShutdown();
     DBListShutdown();
+
+    delete gImmThreads;
+    gImmThreads=NULL;
 
 }   // Env::Shutdown
 

--- a/util/env_posix.cc
+++ b/util/env_posix.cc
@@ -29,9 +29,11 @@
 #include "port/port.h"
 #include "util/crc32c.h"
 #include "util/db_list.h"
+#include "util/hot_threads.h"
 #include "util/logging.h"
 #include "util/mutexlock.h"
 #include "util/posix_logger.h"
+#include "util/thread_tasks.h"
 #include "util/throttle.h"
 #include "db/dbformat.h"
 #include "leveldb/perf_count.h"
@@ -1239,6 +1241,9 @@ static void InitDefaultEnv()
 
     PerformanceCounters::Init(false);
 
+    gImmThreads=new HotThreadPool(7, ePerfDebug1, ePerfDebug2,
+                                  ePerfDebug3, ePerfDebug4);
+
     started=true;
 }
 
@@ -1267,6 +1272,9 @@ void Env::Shutdown()
 
     ComparatorShutdown();
     DBListShutdown();
+
+    delete gImmThreads;
+    gImmThreads=NULL;
 
 }   // Env::Shutdown
 

--- a/util/hot_threads.cc
+++ b/util/hot_threads.cc
@@ -34,6 +34,8 @@ namespace leveldb {
 
 HotThreadPool * gImmThreads=NULL;
 
+HotThreadPool * gWriteThreads=NULL;
+
 
 void *ThreadStaticEntry(void *args)
 {

--- a/util/hot_threads.cc
+++ b/util/hot_threads.cc
@@ -1,0 +1,281 @@
+// -------------------------------------------------------------------
+//
+// hot_threads.cc
+//
+// Copyright (c) 2011-2013 Basho Technologies, Inc. All Rights Reserved.
+//
+// This file is provided to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file
+// except in compliance with the License.  You may obtain
+// a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+// HotThread is a subtle variation on the eleveldb_thread_pool.  Both
+//  represent a design pattern that is tested to perform better under
+//  the Erlang VM than other traditional designs.  
+// -------------------------------------------------------------------
+
+#include "leveldb/atomics.h"
+#include "util/hot_threads.h"
+#include "util/thread_tasks.h"
+
+namespace leveldb {
+
+HotThreadPool * gImmThreads=NULL;
+
+
+
+void *ThreadStaticEntry(void *args)
+{
+    HotThread &tdata = *(HotThread *)args;
+
+    return(tdata.ThreadRoutine());
+
+}   // ThreadStaticEntry
+
+
+/**
+ * Worker threads:  worker threads have 3 states:
+ *  A. doing nothing, available to be claimed: m_Available=1
+ *  B. processing work passed by Erlang thread: m_Available=0, m_DirectWork=<non-null>
+ *  C. processing backlog queue of work: m_Available=0, m_DirectWork=NULL
+ */
+void *
+HotThread::ThreadRoutine()
+{
+    ThreadTask * submission;
+
+    submission=NULL;
+
+    while(!m_Pool.m_Shutdown)
+    {
+        // is work assigned yet?
+        //  check backlog work queue if not
+        if (NULL==submission)
+        {
+            // test non-blocking size for hint (much faster)
+            if (0!=m_Pool.m_WorkQueueAtomic)
+            {
+                // retest with locking
+                SpinLock lock(&m_Pool.m_QueueLock);
+
+                if (!m_Pool.m_WorkQueue.empty())
+                {
+                    submission=m_Pool.m_WorkQueue.front();
+                    m_Pool.m_WorkQueue.pop_front();
+                    dec_and_fetch(&m_Pool.m_WorkQueueAtomic);
+                    m_Pool.IncWorkDequeued();
+                    m_Pool.IncWorkWeighted(2);
+                }   // if
+            }   // if
+        }   // if
+
+
+        // a work item identified (direct or queue), work it!
+        //  then loop to test queue again
+        if (NULL!=submission)
+        {
+            // execute the job
+            (*submission)();
+
+            submission->RefDec();
+
+            submission=NULL;
+        }   // if
+
+        // no work found, attempt to go into wait state
+        //  (but retest queue before sleep due to race condition)
+        else
+        {
+            MutexLock lock(&m_Mutex);
+
+            m_DirectWork=NULL; // safety
+
+            // only wait if we are really sure no work pending
+            if (0==m_Pool.m_WorkQueueAtomic)
+	    {
+                // yes, thread going to wait. set available now.
+	        m_Available=1;
+                m_Condition.Wait();
+	    }    // if
+
+            m_Available=0;    // safety
+            submission=(ThreadTask *)m_DirectWork; // NULL is valid
+            m_DirectWork=NULL;// safety
+        }   // else
+    }   // while
+
+    return 0;
+
+}   // HotThread::ThreadRoutine
+
+
+HotThreadPool::HotThreadPool(
+    const size_t PoolSize,
+    enum PerformanceCountersEnum Direct,
+    enum PerformanceCountersEnum Queued,
+    enum PerformanceCountersEnum Dequeued,
+    enum PerformanceCountersEnum Weighted)
+    : m_WorkQueueAtomic(0),
+          m_Shutdown(false),
+          m_DirectCounter(Direct), m_QueuedCounter(Queued),
+          m_DequeuedCounter(Dequeued), m_WeightedCounter(Weighted)
+{
+    int ret_val;
+    size_t loop;
+    HotThread * hot_ptr;
+
+    ret_val=0;
+    for (loop=0; loop<PoolSize && 0==ret_val; ++loop)
+    {
+        hot_ptr=new HotThread(*this);
+
+        ret_val=pthread_create(&hot_ptr->m_ThreadId, NULL,  &ThreadStaticEntry, hot_ptr);
+        if (0==ret_val)
+            m_Threads.push_back(hot_ptr);
+        else
+            delete hot_ptr;
+    }   // for
+
+    m_Shutdown=(0!=ret_val);
+
+    return;
+
+}   // HotThreadPool::HotThreadPool
+
+
+HotThreadPool::~HotThreadPool()
+{
+    ThreadPool_t::iterator thread_it;
+    WorkQueue_t::iterator work_it;
+    // set flag
+    m_Shutdown=true;
+
+    // get all threads stopped
+    for (thread_it=m_Threads.begin(); m_Threads.end()!=thread_it; ++thread_it)
+    {
+        {
+            MutexLock lock(&(*thread_it)->m_Mutex);
+            (*thread_it)->m_Condition.SignalAll();
+        }   // lock
+
+        pthread_join((*thread_it)->m_ThreadId, NULL);
+        delete *thread_it;
+    }   // for
+    
+    // release any objects hanging in work queue
+    for (work_it=m_WorkQueue.begin(); m_WorkQueue.end()!=work_it; ++work_it)
+    {
+        (*work_it)->RefDec();
+    }   // for
+
+    return;
+
+}   // HotThreadPool::~HotThreadPool
+
+
+bool                           // returns true if available worker thread found and claimed
+HotThreadPool::FindWaitingThread(
+    ThreadTask * work) // non-NULL to pass current work directly to a thread,
+                               // NULL to potentially nudge an available worker toward backlog queue
+{
+    bool ret_flag;
+    size_t start, index, pool_size;
+
+    ret_flag=false;
+
+    // pick "random" place in thread list.  hopefully
+    //  list size is prime number.
+    pool_size=m_Threads.size();
+    start=(size_t)pthread_self() % pool_size;
+    index=start;
+
+    do
+    {
+        // perform quick test to see thread available
+        if (0!=m_Threads[index]->m_Available && !shutdown_pending())
+        {
+            // perform expensive compare and swap to potentially
+            //  claim worker thread (this is an exclusive claim to the worker)
+            ret_flag = compare_and_swap(&m_Threads[index]->m_Available, 1, 0);
+
+            // the compare/swap only succeeds if worker thread is sitting on
+            //  pthread_cond_wait ... or is about to be there but is holding
+            //  the mutex already
+            if (ret_flag)
+            {
+
+                // man page says mutex lock optional, experience in
+                //  this code says it is not.  using broadcast instead
+                //  of signal to cover one other race condition
+                //  that should never happen with single thread waiting.
+                MutexLock lock(&m_Threads[index]->m_Mutex);
+                m_Threads[index]->m_DirectWork=work;
+                m_Threads[index]->m_Condition.SignalAll();
+            }   // if
+        }   // if
+
+        index=(index+1)%pool_size;
+
+    } while(index!=start && !ret_flag);
+
+    return(ret_flag);
+
+}   // FindWaitingThread
+
+
+bool 
+HotThreadPool::Submit(
+    ThreadTask* item)
+{
+    bool ret_flag(false);
+
+    if (NULL!=item)
+    {
+        item->RefInc();
+
+        if(shutdown_pending())
+        {
+            item->RefDec();
+            ret_flag=false;
+        }   // if
+
+        // try to give work to a waiting thread first
+        else if (!FindWaitingThread(item))
+        {
+            // no waiting threads, put on backlog queue
+            {
+                SpinLock lock(&m_QueueLock);
+                inc_and_fetch(&m_WorkQueueAtomic);
+                m_WorkQueue.push_back(item);
+            }
+
+            // to address race condition, thread might be waiting now
+            FindWaitingThread(NULL);
+
+            IncWorkQueued();
+            ret_flag=true;
+        }   // if
+        else
+        {
+            IncWorkDirect();
+            ret_flag=true;
+        }   // else
+    }   // if
+
+    return(ret_flag);
+
+}   // HotThreadPool::Submit
+
+};  // namespace leveldb

--- a/util/hot_threads.cc
+++ b/util/hot_threads.cc
@@ -200,10 +200,10 @@ HotThreadPool::HotThreadPool(
     enum PerformanceCountersEnum Queued,
     enum PerformanceCountersEnum Dequeued,
     enum PerformanceCountersEnum Weighted)
-    : m_WorkQueueAtomic(0),
-          m_Shutdown(false), m_QueueThread(*this),
-          m_DirectCounter(Direct), m_QueuedCounter(Queued),
-          m_DequeuedCounter(Dequeued), m_WeightedCounter(Weighted)
+    : m_Shutdown(false), m_QueueThread(*this),
+      m_WorkQueueAtomic(0),
+      m_DirectCounter(Direct), m_QueuedCounter(Queued),
+      m_DequeuedCounter(Dequeued), m_WeightedCounter(Weighted)
 {
     int ret_val;
     size_t loop;

--- a/util/hot_threads.h
+++ b/util/hot_threads.h
@@ -1,0 +1,135 @@
+// -------------------------------------------------------------------
+//
+// hot_threads.h
+//
+// Copyright (c) 2011-2013 Basho Technologies, Inc. All Rights Reserved.
+//
+// This file is provided to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file
+// except in compliance with the License.  You may obtain
+// a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+// HotThread is a subtle variation on the eleveldb_thread_pool.  Both
+//  represent a design pattern that is tested to perform better under
+//  the Erlang VM than other traditional designs.
+// -------------------------------------------------------------------
+
+#ifndef STORAGE_LEVELDB_INCLUDE_HOT_THREADS_H_
+#define STORAGE_LEVELDB_INCLUDE_HOT_THREADS_H_
+
+#include <pthread.h>
+#include <deque>
+#include <vector>
+
+#include "leveldb/perf_count.h"
+#include "port/port.h"
+#include "util/mutexlock.h"
+
+namespace leveldb
+{
+
+// forward declare
+class ThreadTask;
+
+/**
+ * Meta / managment data related to a worker thread.
+ */
+struct HotThread
+{
+public:
+    pthread_t m_ThreadId;                //!< handle for this thread
+
+    volatile uint32_t m_Available;       //!< 1 if thread waiting, using standard type for atomic operation
+    class HotThreadPool & m_Pool;        //!< parent pool object
+    volatile ThreadTask * m_DirectWork;    //!< work passed direct to thread
+
+    port::Mutex m_Mutex;             //!< mutex for condition variable
+    port::CondVar m_Condition;          //!< condition for thread waiting
+
+public:
+    HotThread(class HotThreadPool & Pool)
+    : m_Available(0), m_Pool(Pool), m_DirectWork(NULL),
+        m_Condition(&m_Mutex)
+    {}   // HotThread
+
+    virtual ~HotThread() {};
+
+    // actual work loop
+    void * ThreadRoutine();
+
+private:
+    HotThread();                              // no default
+    HotThread(const HotThread &);             // no copy
+    HotThread & operator=(const HotThread&);  // no assign
+
+};  // class HotThread
+
+
+
+class HotThreadPool
+{
+public:
+
+    typedef std::deque<ThreadTask*> WorkQueue_t;
+    typedef std::vector<HotThread *>   ThreadPool_t;
+
+    volatile bool m_Shutdown;            //!< should we stop threads and shut down?
+
+    ThreadPool_t  m_Threads;
+    WorkQueue_t   m_WorkQueue;
+    port::Spin m_QueueLock;                    //!< protects access to work_queue
+    volatile size_t m_WorkQueueAtomic;   //!< atomic size to parallel work_queue.size().
+
+    enum PerformanceCountersEnum m_DirectCounter;
+    enum PerformanceCountersEnum m_QueuedCounter;
+    enum PerformanceCountersEnum m_DequeuedCounter;
+    enum PerformanceCountersEnum m_WeightedCounter;
+
+public:
+    HotThreadPool(const size_t thread_pool_size,
+                  enum PerformanceCountersEnum Direct,
+                  enum PerformanceCountersEnum Queued,
+                  enum PerformanceCountersEnum Dequeued,
+                  enum PerformanceCountersEnum Weighted);
+
+    virtual ~HotThreadPool();
+
+    static void *ThreadStart(void *args);
+
+    bool FindWaitingThread(ThreadTask * work);
+
+    bool Submit(ThreadTask * item);
+
+    size_t work_queue_size() const { return m_WorkQueue.size();}
+    bool shutdown_pending() const  { return m_Shutdown; }
+    leveldb::PerformanceCounters * perf() const {return(leveldb::gPerfCounters);};
+
+    void IncWorkDirect() {leveldb::gPerfCounters->Inc(m_DirectCounter);};
+    void IncWorkQueued() {leveldb::gPerfCounters->Inc(m_QueuedCounter);};
+    void IncWorkDequeued() {leveldb::gPerfCounters->Inc(m_DequeuedCounter);};
+    void IncWorkWeighted(uint64_t Count) {leveldb::gPerfCounters->Add(m_WeightedCounter, Count);};
+
+private:
+    HotThreadPool(const HotThreadPool &);             // nocopy
+    HotThreadPool& operator=(const HotThreadPool&);  // nocopyassign
+
+};  // class HotThreadPool
+
+extern HotThreadPool * gImmThreads;
+
+} // namespace leveldb
+
+
+#endif  // STORAGE_LEVELDB_INCLUDE_HOT_THREADS_H_

--- a/util/hot_threads.h
+++ b/util/hot_threads.h
@@ -103,7 +103,6 @@ private:
 };  // class QueueThread
 
 
-
 class HotThreadPool
 {
 public:
@@ -118,6 +117,7 @@ public:
     QueueThread m_QueueThread;           //!< one slow response worker to cover edge case
     WorkQueue_t   m_WorkQueue;
     port::Spin m_QueueLock;              //!< protects access to work_queue
+
     volatile size_t m_WorkQueueAtomic;   //!< atomic size to parallel work_queue.size().
 
     enum PerformanceCountersEnum m_DirectCounter;

--- a/util/hot_threads.h
+++ b/util/hot_threads.h
@@ -81,6 +81,7 @@ private:
 struct QueueThread
 {
 public:
+    bool m_ThreadGood;                   //!< true if thread and semaphore good
     pthread_t m_ThreadId;                //!< handle for this thread
 
     class HotThreadPool & m_Pool;        //!< parent pool object
@@ -90,7 +91,7 @@ public:
 public:
     QueueThread(class HotThreadPool & Pool);
 
-    virtual ~QueueThread() {sem_destroy(&m_Semaphore);};
+    virtual ~QueueThread();
 
     // actual work loop
     void * QueueThreadRoutine();

--- a/util/hot_threads.h
+++ b/util/hot_threads.h
@@ -115,10 +115,10 @@ public:
 
     ThreadPool_t  m_Threads;             //!< pool of fast response workers
 
-    QueueThread m_QueueThread;           //!< one slow response worker to cover edge case
     WorkQueue_t   m_WorkQueue;
     port::Spin m_QueueLock;              //!< protects access to work_queue
     volatile size_t m_WorkQueueAtomic;   //!< atomic size to parallel work_queue.size().
+    QueueThread m_QueueThread;           //!< one slow response worker to cover edge case
 
     enum PerformanceCountersEnum m_DirectCounter;
     enum PerformanceCountersEnum m_QueuedCounter;

--- a/util/hot_threads.h
+++ b/util/hot_threads.h
@@ -117,7 +117,6 @@ public:
     QueueThread m_QueueThread;           //!< one slow response worker to cover edge case
     WorkQueue_t   m_WorkQueue;
     port::Spin m_QueueLock;              //!< protects access to work_queue
-
     volatile size_t m_WorkQueueAtomic;   //!< atomic size to parallel work_queue.size().
 
     enum PerformanceCountersEnum m_DirectCounter;

--- a/util/hot_threads.h
+++ b/util/hot_threads.h
@@ -155,6 +155,7 @@ private:
 };  // class HotThreadPool
 
 extern HotThreadPool * gImmThreads;
+extern HotThreadPool * gWriteThreads;
 
 } // namespace leveldb
 

--- a/util/perf_count.cc
+++ b/util/perf_count.cc
@@ -516,7 +516,8 @@ PerformanceCounters * gPerfCounters(&LocalStartupCounters);
         "ThrottleBacklog1",
         "ThrottleCompacts1",
         "BGWriteError",
-        "ThrottleWait"
+        "ThrottleWait",
+        "ThreadError"
     };
 
 

--- a/util/perf_count.cc
+++ b/util/perf_count.cc
@@ -515,7 +515,8 @@ PerformanceCounters * gPerfCounters(&LocalStartupCounters);
         "ThrottleKeys1",
         "ThrottleBacklog1",
         "ThrottleCompacts1",
-        "BGWriteError"
+        "BGWriteError",
+        "ThrottleWait"
     };
 
 

--- a/util/thread_tasks.h
+++ b/util/thread_tasks.h
@@ -42,13 +42,14 @@ namespace leveldb {
 class ThreadTask
 {
 public:
+    uint64_t m_QueueStart;        //!< NowMicros() time placed on work queue
 
 protected:
     volatile uint32_t m_RefCount;
 
  public:
-    ThreadTask() 
-        : m_RefCount(0) {};
+    ThreadTask()
+        : m_QueueStart(0), m_RefCount(0) {};
 
     virtual ~ThreadTask() {};
 
@@ -61,7 +62,7 @@ protected:
         current_refs=dec_and_fetch(&m_RefCount);
         if (0==current_refs)
             delete this;
-        
+
         return(current_refs);
 
     }   // RefObject::RefDec

--- a/util/thread_tasks.h
+++ b/util/thread_tasks.h
@@ -1,0 +1,106 @@
+// -------------------------------------------------------------------
+//
+// thread_tasks.h
+//
+// Copyright (c) 2011-2013 Basho Technologies, Inc. All Rights Reserved.
+//
+// This file is provided to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file
+// except in compliance with the License.  You may obtain
+// a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+//  Modeled after eleveldb's workitems.h/.cc
+// -------------------------------------------------------------------
+
+
+#ifndef STORAGE_LEVELDB_INCLUDE_THREAD_TASKS_H_
+#define STORAGE_LEVELDB_INCLUDE_THREAD_TASKS_H_
+
+#include <stdint.h>
+
+#include "leveldb/atomics.h"
+#include "db/db_impl.h"
+
+namespace leveldb {
+
+
+/**
+ * Virtual base class for leveldb background tasks
+ */
+class ThreadTask
+{
+public:
+
+protected:
+    volatile uint32_t m_RefCount;
+
+ public:
+    ThreadTask() 
+        : m_RefCount(0) {};
+
+    virtual ~ThreadTask() {};
+
+    uint32_t RefInc() {return(inc_and_fetch(&m_RefCount));};
+
+    uint32_t RefDec()
+    {
+        uint32_t current_refs;
+
+        current_refs=dec_and_fetch(&m_RefCount);
+        if (0==current_refs)
+            delete this;
+        
+        return(current_refs);
+
+    }   // RefObject::RefDec
+
+    // this is the derived object's task routine
+    virtual void operator()()     = 0;
+
+private:
+    ThreadTask(const ThreadTask &);
+    ThreadTask & operator=(const ThreadTask &);
+
+};  // class ThreadTask
+
+
+/**
+ * Background write of imm buffer to Level-0 file
+ */
+
+class ImmWriteTask : public ThreadTask
+{
+protected:
+    DBImpl * m_DBImpl;
+
+public:
+    ImmWriteTask(DBImpl * Db)
+        : m_DBImpl(Db) {};
+
+    virtual ~ImmWriteTask() {};
+
+    virtual void operator()() {m_DBImpl->BackgroundImmCompactCall();};
+
+private:
+    ImmWriteTask();
+    ImmWriteTask(const ImmWriteTask &);
+    ImmWriteTask & operator=(const ImmWriteTask &);
+
+};  // class ImmWriteTask
+
+} // namespace leveldb
+
+
+#endif  // INCL_WORKITEMS_H


### PR DESCRIPTION
This is branch contains the threading code originally developed for the eleveldb async NIF.  It was previously delivered in leveldb as part of a patch in branch 1.2.4-turner.  Joe B. spotted an unlikely, but real, race condition that this branch addressed via the QueueThread object.

Today only Imm to Level-0 compactions post to a hot thread pool.  The goal is to move background disk writes and all background compactions to a series of specialized hot thread pools ... but that will be a different branch.
