### PR TITLE
change build_detect_platform to check for OS X Mavericks

### DIFF
--- a/build_detect_platform
+++ b/build_detect_platform
@@ -59,7 +59,16 @@ PLATFORM_SHARED_VERSIONED=true
 case "$TARGET_OS" in
     Darwin)
         PLATFORM=OS_MACOSX
-        COMMON_FLAGS="-fno-builtin-memcmp -DOS_MACOSX"
+        oIFS="$IFS"; IFS=.
+        set `uname -r`
+        IFS="$oIFS"
+        if [ "$1" -ge 13 ]; then
+            # assume clang compiler
+            COMMON_FLAGS="-mmacosx-version-min=10.8 -DOS_MACOSX"
+            PLATFORM_LDFLAGS="-mmacosx-version-min=10.8"
+        else
+            COMMON_FLAGS="-fno-builtin-memcmp -DOS_MACOSX"
+        fi
         PLATFORM_SHARED_EXT=dylib
         PLATFORM_SHARED_LDFLAGS="-dynamiclib -install_name "
         PORT_FILE=port/port_posix.cc


### PR DESCRIPTION
On Mavericks clang is the default compiler, so modify build_detect_platform
to detect that OS X version and set the necessary compiler and linker
switches.

Successfully tested on Mavericks, Mountain Lion, and Lion.

I strongly suggest rebasing this to master rather than merging, as that way the corresponding changes in the eleveldb c_src/build_deps.sh script will continue to pick up the right leveldb commit sha created by this commit.
