### PR TITLE
Mv flexcache5

### DIFF
--- a/include/leveldb/env.h
+++ b/include/leveldb/env.h
@@ -234,6 +234,9 @@ class RandomAccessFile {
 
   // Riak optimization:  allows advising Linux page cache
   virtual void SetForCompaction(uint64_t file_size) {};
+
+  // Riak addition:  size of this structure in bytes
+  virtual size_t ObjectSize() {return(sizeof(RandomAccessFile));};
 };
 
 // A file abstraction for sequential writing.  The implementation

--- a/include/leveldb/perf_count.h
+++ b/include/leveldb/perf_count.h
@@ -204,6 +204,12 @@ enum PerformanceCountersEnum
     ePerfBGUnmapDequeued=75,//!< count Unmap operations removed from queue
     ePerfBGUnmapWeighted=76,//!< total microseconds item spent on queue
 
+    ePerfFileCacheInsert=77,//!< total bytes inserted into file cache
+    ePerfFileCacheRemove=78,//!< total bytes removed from file cache
+
+    ePerfBlockCacheInsert=79,//!< total bytes inserted into block cache
+    ePerfBlockCacheRemove=80,//!< total bytes removed from block cache
+
     // must follow last index name to represent size of array
     //  (ASSUMES previous enum is highest value)
     ePerfCountEnumSize,     //!< size of the array described by the enum values

--- a/table/table.cc
+++ b/table/table.cc
@@ -267,7 +267,7 @@ Iterator* Table::BlockReader(void* arg,
           if (contents.cachable && options.fill_cache) {
             cache_handle = block_cache->Insert(
                 key, block,
-                (block->size() + block_cache->EntryOverheadSize() + sizeof(cache_key_buffer)),
+                (block->size() + /*block_cache->EntryOverheadSize() +*/ sizeof(cache_key_buffer)),
                 &DeleteCachedBlock);
           }
         }
@@ -375,7 +375,7 @@ Table::TEST_GetIndexBlock() {return(rep_->index_block);};
 size_t
 Table::TableObjectSize()
 {
-    return(sizeof(Table) + sizeof(Table::Rep) + rep_->index_block->size() + rep_->filter_data_size);
+    return(sizeof(Table) + sizeof(Table::Rep) + rep_->index_block->size() + rep_->filter_data_size + rep_->file->ObjectSize());
 };
 
 size_t

--- a/table/table.cc
+++ b/table/table.cc
@@ -375,7 +375,8 @@ Table::TEST_GetIndexBlock() {return(rep_->index_block);};
 size_t
 Table::TableObjectSize()
 {
-    return(sizeof(Table) + sizeof(Table::Rep) + rep_->index_block->size() + rep_->filter_data_size + rep_->file->ObjectSize());
+    return(sizeof(Table) + sizeof(Table::Rep) + rep_->index_block->size() + rep_->filter_data_size + rep_->file->ObjectSize()
+           + sizeof(FilterBlockReader) + sizeof(Block));
 };
 
 size_t

--- a/util/cache2.cc
+++ b/util/cache2.cc
@@ -631,7 +631,7 @@ Cache::Handle* LRUCache2::Insert(
         SpinLock l(&spin_);
 
         LRU_Append(e);
-        add_and_fetch(parent_->GetUsagePtr(), e->charge);
+        add_and_fetch(parent_->GetUsagePtr(), (uint64_t)e->charge);
 
         LRUHandle2* old = table_.Insert(e);
         if (old != NULL) {

--- a/util/cache2_test.cc
+++ b/util/cache2_test.cc
@@ -250,7 +250,7 @@ TEST(CacheTest, FileCacheExpire) {
     }   // while
 
     // did file cache take away?
-    ASSERT_EQ(beginning_size-(kCacheSize/2)*kOneMeg, double_cache_.GetCapacity(false));
+    ASSERT_GT(beginning_size-(kCacheSize/2)*kOneMeg, double_cache_.GetCapacity(false));
 
     // sleep two seconds
     Env::Default()->SleepForMicroseconds(2000000);
@@ -278,7 +278,7 @@ TEST(CacheTest, FileCacheExpire) {
     }   // while
 
     // did file cache take away?
-    ASSERT_EQ(beginning_size-(kCacheSize/2)*kOneMeg, double_cache_.GetCapacity(false));
+    ASSERT_GT(beginning_size-(kCacheSize/2)*kOneMeg, double_cache_.GetCapacity(false));
 
     // sleep two seconds
     Env::Default()->SleepForMicroseconds(2000000);
@@ -287,7 +287,7 @@ TEST(CacheTest, FileCacheExpire) {
     double_cache_.PurgeExpiredFiles();
 
     // did only half get purged
-    ASSERT_EQ(beginning_size-(kCacheSize/4)*kOneMeg, double_cache_.GetCapacity(false));
+    ASSERT_GT(beginning_size-(kCacheSize/4)*kOneMeg, double_cache_.GetCapacity(false));
 
     // reset timeout to default
     double_cache_.SetFileTimeout(expire_default);

--- a/util/env_posix.cc
+++ b/util/env_posix.cc
@@ -177,6 +177,9 @@ class PosixRandomAccessFile: public RandomAccessFile {
 
   };
 
+  // Riak addition:  size of this structure in bytes
+  virtual size_t ObjectSize() {return(sizeof(PosixRandomAccessFile)+filename_.length());};
+
 };
 
 

--- a/util/flexcache_test.cc
+++ b/util/flexcache_test.cc
@@ -126,6 +126,9 @@ TEST(FlexCacheTest, UserSizing) {
         st=DestroyDB(dbname, options);
         ASSERT_OK(st);
     }   // for
+
+    delete options.filter_policy;
+    options.filter_policy=NULL;
 }
 
 TEST(FlexCacheTest, MixedSizing) {
@@ -230,6 +233,9 @@ TEST(FlexCacheTest, MixedSizing) {
         st=DestroyDB(dbname, options);
         ASSERT_OK(st);
     }   // for
+
+    delete options.filter_policy;
+    options.filter_policy=NULL;
 }
 
 

--- a/util/perf_count.cc
+++ b/util/perf_count.cc
@@ -228,17 +228,15 @@ PerformanceCounters * gPerfCounters(&LocalStartupCounters);
             ret_val=-1;
 
         // does the shared memory already exists (and of proper size if writing)
-        should_create=(0!=ret_val || ((shm_info.shm_segsz < sizeof(PerformanceCounters)) && !IsReadOnly));
+        should_create=(0!=ret_val || (shm_info.shm_segsz < sizeof(PerformanceCounters))) && !IsReadOnly;
 
         // should old shared memory be deleted?
         if (should_create && 0==ret_val)
         {
             ret_val=shmctl(id, IPC_RMID, &shm_info);
+            good=(0==ret_val);
             if (0!=ret_val)
-            {
                 syslog(LOG_ERR, "shmctl IPC_RMID failed [%d, %m]", errno);
-                good=false;
-            }   // if
         }   // if
 
         // attempt to attach/create to shared memory instance
@@ -596,7 +594,11 @@ PerformanceCounters * gPerfCounters(&LocalStartupCounters);
         "BGUnmapDirect",
         "BGUnmapQueued",
         "BGUnmapDequeued",
-        "BGUnmapWeighted"
+        "BGUnmapWeighted",
+        "FileCacheInsert",
+        "FileCacheRemove",
+        "BlockCacheInsert",
+        "BlockCacheRemove"
     };
 
 


### PR DESCRIPTION
Clean up of the bytes used accounting in flexcache.  Both the block cache and the file cache objects were missing byte counts of "attached" objects.  These missing byte counts caused flexcache to under-account for bytes in use.  Therefore the total amount of memory used by the caches was actually greater than the cache limits.
