### PR TITLE
Mv hot threads2

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -976,7 +976,8 @@ DBImpl::BackgroundImmCompactCall() {
   if (shutting_down_.Acquire_Load()) {
 
     // must abandon data in memory ... hope recovery log works
-    imm_->Unref();
+    if (NULL!=imm_)
+      imm_->Unref();
     imm_ = NULL;
     has_imm_.Release_Store(NULL);
   } // if

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -851,7 +851,7 @@ void DBImpl::MaybeScheduleCompaction() {
           // support manual compaction under hot threads
           versions_->SetCompactionSubmitted(manual_compaction_->level);
           ThreadTask * task=new CompactionTask(this, NULL);
-          gCompactionThreads->Submit(task);
+          gCompactionThreads->Submit(task, true);
       }   // else if
   }   // if
 }
@@ -1687,7 +1687,7 @@ Status DBImpl::MakeRoomForWrite(bool force) {
       if (NULL!=imm_)
       {
          ThreadTask * task=new ImmWriteTask(this);
-         gImmThreads->Submit(task);
+         gImmThreads->Submit(task, true);
       }
       mem_ = new MemTable(internal_comparator_);
       mem_->Ref();

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -871,6 +871,11 @@ void DBImpl::BackgroundCall2(
   else
       level=0;
 
+  if (0==level)
+      gPerfCounters->Inc(ePerfBGCompactLevel0);
+  else
+      gPerfCounters->Inc(ePerfBGNormal);
+
   versions_->SetCompactionRunning(level);
 
   if (!shutting_down_.Acquire_Load()) {
@@ -1663,6 +1668,7 @@ Status DBImpl::MakeRoomForWrite(bool force) {
       // There are too many level-0 files.
       Log(options_.info_log, "waiting...\n");
       gPerfCounters->Inc(ePerfWriteWaitLevel0);
+      MaybeScheduleCompaction();
       bg_cv_.Wait();
       Log(options_.info_log, "running...\n");
     } else {

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -856,42 +856,6 @@ void DBImpl::MaybeScheduleCompaction() {
   }   // if
 }
 
-void DBImpl::BGWork(void* db) {
-  reinterpret_cast<DBImpl*>(db)->BackgroundCall();
-}
-
-void DBImpl::BackgroundCall() {
-  MutexLock l(&mutex_);
-  assert(bg_compaction_scheduled_);
-
-  ++running_compactions_;
-
-  if (!shutting_down_.Acquire_Load()) {
-    Status s = BackgroundCompaction();
-    if (!s.ok()) {
-      // Wait a little bit before retrying background compaction in
-      // case this is an environmental problem and we do not want to
-      // chew up resources for failed compactions for the duration of
-      // the problem.
-      bg_cv_.SignalAll();  // In case a waiter can proceed despite the error
-      Log(options_.info_log, "Waiting after background compaction error: %s",
-          s.ToString().c_str());
-      mutex_.Unlock();
-      env_->SleepForMicroseconds(1000000);
-      mutex_.Lock();
-    }
-  }
-  bg_compaction_scheduled_ = false;
-  --running_compactions_;
-
-  // Previous compaction may have produced too many files in a level,
-  // so reschedule another compaction if needed.
-  if (!options_.is_repair)
-      MaybeScheduleCompaction();
-  bg_cv_.SignalAll();
-
-}
-
 
 void DBImpl::BackgroundCall2(
     Compaction * Compact) {

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -67,6 +67,7 @@ class DBImpl : public DB {
   size_t GetCacheCapacity() {return(double_cache.GetCapacity(false));}
   void PurgeExpiredFileCache() {double_cache.PurgeExpiredFiles();};
 
+  void BackgroundCall2(Compaction * Compact);
   void BackgroundImmCompactCall();
   bool IsCompactionScheduled() {mutex_.AssertHeld(); return(bg_compaction_scheduled_ || NULL!=imm_);};
   uint32_t RunningCompactionCount() {mutex_.AssertHeld(); return(running_compactions_);};
@@ -113,7 +114,7 @@ class DBImpl : public DB {
   void MaybeScheduleCompaction();
   static void BGWork(void* db);
   void BackgroundCall();
-  Status BackgroundCompaction();
+  Status BackgroundCompaction(Compaction * Compact=NULL);
   void CleanupCompaction(CompactionState* compact);
   Status DoCompactionWork(CompactionState* compact);
   int64_t PrioritizeWork(bool IsLevel0);

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -69,7 +69,7 @@ class DBImpl : public DB {
 
   void BackgroundCall2(Compaction * Compact);
   void BackgroundImmCompactCall();
-  bool IsCompactionScheduled() {mutex_.AssertHeld(); return(bg_compaction_scheduled_ || NULL!=imm_);};
+  bool IsCompactionScheduled();
   uint32_t RunningCompactionCount() {mutex_.AssertHeld(); return(running_compactions_);};
 
  private:

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -112,8 +112,7 @@ class DBImpl : public DB {
   WriteBatch* BuildBatchGroup(Writer** last_writer);
 
   void MaybeScheduleCompaction();
-  static void BGWork(void* db);
-  void BackgroundCall();
+
   Status BackgroundCompaction(Compaction * Compact=NULL);
   void CleanupCompaction(CompactionState* compact);
   Status DoCompactionWork(CompactionState* compact);

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1457,6 +1457,8 @@ VersionSet::PickCompaction(
   // submit a work object for every valid compaction needed
   while(Finalize(current_))
   {
+      c=NULL;
+
       // We prefer compactions triggered by too much data in a level over
       // the compactions triggered by seeks.  (Riak redefines "seeks" to
       // "files containing delete tombstones")

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1075,7 +1075,7 @@ VersionSet::Finalize(Version* v)
 
     compaction_found=false;
     is_grooming=false;
-    for (int level = 0; level < config::kNumLevels-1 && !compaction_found; level++) 
+    for (int level = v->compaction_level_+1; level < config::kNumLevels-1 && !compaction_found; level++) 
     {
         bool compact_ok;
         double score;
@@ -1474,7 +1474,6 @@ VersionSet::PickCompaction(
       const bool seek_compaction = (current_->file_to_compact_ != NULL);
       if (size_compaction) 
       {
-          bool compact_ok;
           level = current_->compaction_level_;
           assert(level >= 0);
           assert(level+1 < config::kNumLevels);

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -139,6 +139,7 @@ class Version {
   // are initialized by Finalize().
   double compaction_score_;
   int compaction_level_;
+  bool compaction_grooming_;
   volatile int write_penalty_;
 
   explicit Version(VersionSet* vset)

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -277,6 +277,7 @@ class VersionSet {
     char buffer[100];
   };
   const char* LevelSummary(LevelSummaryStorage* scratch) const;
+  const char* CompactionSummary(LevelSummaryStorage* scratch) const;
 
   TableCache* GetTableCache() {return(table_cache_);};
 

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -234,7 +234,10 @@ class VersionSet {
   // Returns NULL if there is no compaction to be done.
   // Otherwise returns a pointer to a heap-allocated object that
   // describes the compaction.  Caller should delete the result.
-  Compaction* PickCompaction();
+  //
+  // Riak October 2013:  Pick Compaction now posts work directly
+  //  to hot_thread pools
+  void PickCompaction(class DBImpl * db_impl);
 
   // Return a compaction object for compacting the range [begin,end] in
   // the specified level.  Returns NULL if there is nothing in that
@@ -276,13 +279,21 @@ class VersionSet {
 
   TableCache* GetTableCache() {return(table_cache_);};
 
+  void SetCompactionRunning(int level) 
+  {m_CompactionStatus[level].m_Running=true;}
+
+  void SetCompactionDone(int level) 
+  {   m_CompactionStatus[level].m_Running=false;
+      m_CompactionStatus[level].m_Submitted=false;}
+
  private:
   class Builder;
 
   friend class Compaction;
   friend class Version;
 
-  void Finalize(Version* v);
+  bool Finalize(Version* v);
+  void UpdatePenalty(Version *v);
 
   void GetRange(const std::vector<FileMetaData*>& inputs,
                 InternalKey* smallest,
@@ -325,6 +336,17 @@ class VersionSet {
   // Riak allows multiple compaction threads, this mutex allows
   //  only one to write to manifest at a time.  Only used in LogAndApply
   port::Mutex manifest_mutex_;
+
+  struct CompactionStatus_s
+  {
+      bool m_Submitted;     //!< level submitted to hot thread pool
+      bool m_Running;       //!< thread actually running compaction
+
+      CompactionStatus_s() 
+      : m_Submitted(false), m_Running(false)
+      {};
+  } m_CompactionStatus[config::kNumLevels];
+
 
   // No copying allowed
   VersionSet(const VersionSet&);

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -279,6 +279,12 @@ class VersionSet {
 
   TableCache* GetTableCache() {return(table_cache_);};
 
+  bool IsCompactionSubmitted(int level) 
+  {return(m_CompactionStatus[level].m_Submitted);}
+
+  void SetCompactionSubmitted(int level) 
+  {m_CompactionStatus[level].m_Submitted=true;}
+
   void SetCompactionRunning(int level) 
   {m_CompactionStatus[level].m_Running=true;}
 

--- a/include/leveldb/env.h
+++ b/include/leveldb/env.h
@@ -151,10 +151,7 @@ class Env {
   // serialized.
   virtual void Schedule(
       void (*function)(void* arg),
-      void* arg,
-      int state=0,
-      bool imm_flag=false,
-      int priority=0) = 0;
+      void* arg) = 0;
 
   // Start a new thread, invoking "function(arg)" within the new thread.
   // When "function(arg)" returns, the thread will be destroyed.
@@ -359,8 +356,8 @@ class EnvWrapper : public Env {
     return target_->LockFile(f, l);
   }
   Status UnlockFile(FileLock* l) { return target_->UnlockFile(l); }
-  void Schedule(void (*f)(void*), void* a, int state=0, bool imm=false, int priority=0) {
-      return target_->Schedule(f, a, state, imm, priority);
+  void Schedule(void (*f)(void*), void* a) {
+      return target_->Schedule(f, a);
   }
   pthread_t StartThread(void (*f)(void*), void* a) {
     return target_->StartThread(f, a);

--- a/include/leveldb/perf_count.h
+++ b/include/leveldb/perf_count.h
@@ -204,6 +204,16 @@ enum PerformanceCountersEnum
     ePerfBGUnmapDequeued=75,//!< count Unmap operations removed from queue
     ePerfBGUnmapWeighted=76,//!< total microseconds item spent on queue
 
+    ePerfBGLevel0Direct=77,  //!< count Level0 compactions happened directly
+    ePerfBGLevel0Queued=78,  //!< count Level0 compactions placed on queue
+    ePerfBGLevel0Dequeued=79,//!< count Level0 compactions removed from queue
+    ePerfBGLevel0Weighted=80,//!< total microseconds item spent on queue
+
+    ePerfBGCompactDirect=81,  //!< count generic compactions happened directly
+    ePerfBGCompactQueued=82,  //!< count generic compactions placed on queue
+    ePerfBGCompactDequeued=83,//!< count generic compactions removed from queue
+    ePerfBGCompactWeighted=84,//!< total microseconds item spent on queue
+
     // must follow last index name to represent size of array
     //  (ASSUMES previous enum is highest value)
     ePerfCountEnumSize,     //!< size of the array described by the enum values

--- a/include/leveldb/perf_count.h
+++ b/include/leveldb/perf_count.h
@@ -194,6 +194,26 @@ enum PerformanceCountersEnum
     ePerfThrottleWait=67,   //!< milliseconds of throttle wait
     ePerfThreadError=68,    //!< system error on thread related call, no LOG access
 
+    ePerfBGImmDirect=69,    //!< count Imm compactions happened directly
+    ePerfBGImmQueued=70,    //!< count Imm compactions placed on queue
+    ePerfBGImmDequeued=71,  //!< count Imm compactions removed from queue
+    ePerfBGImmWeighted=72,  //!< total microseconds item spent on queue
+
+    ePerfBGUnmapDirect=73,  //!< count Unmap operations happened directly
+    ePerfBGUnmapQueued=74,  //!< count Unmap operations placed on queue
+    ePerfBGUnmapDequeued=75,//!< count Unmap operations removed from queue
+    ePerfBGUnmapWeighted=76,//!< total microseconds item spent on queue
+
+    ePerfBGLevel0Direct=77,  //!< count Level0 compactions happened directly
+    ePerfBGLevel0Queued=78,  //!< count Level0 compactions placed on queue
+    ePerfBGLevel0Dequeued=79,//!< count Level0 compactions removed from queue
+    ePerfBGLevel0Weighted=80,//!< total microseconds item spent on queue
+
+    ePerfBGCompactDirect=81,  //!< count generic compactions happened directly
+    ePerfBGCompactQueued=82,  //!< count generic compactions placed on queue
+    ePerfBGCompactDequeued=83,//!< count generic compactions removed from queue
+    ePerfBGCompactWeighted=84,//!< total microseconds item spent on queue
+
     // must follow last index name to represent size of array
     //  (ASSUMES previous enum is highest value)
     ePerfCountEnumSize,     //!< size of the array described by the enum values

--- a/util/env_posix.cc
+++ b/util/env_posix.cc
@@ -1269,6 +1269,10 @@ static void InitDefaultEnv()
                                   ePerfBGImmDequeued, ePerfBGImmWeighted);
     gWriteThreads=new HotThreadPool(7, ePerfBGUnmapDirect, ePerfBGUnmapQueued,
                                     ePerfBGUnmapDequeued, ePerfBGUnmapWeighted);
+    gLevel0Threads=new HotThreadPool(7, ePerfBGLevel0Direct, ePerfBGLevel0Queued,
+                                    ePerfBGLevel0Dequeued, ePerfBGLevel0Weighted);
+    gCompactionThreads=new HotThreadPool(5, ePerfBGCompactDirect, ePerfBGCompactQueued,
+                                    ePerfBGCompactDequeued, ePerfBGCompactWeighted);
 
     started=true;
 }
@@ -1304,6 +1308,12 @@ void Env::Shutdown()
 
     delete gWriteThreads;
     gWriteThreads=NULL;
+
+    delete gLevel0Threads;
+    gLevel0Threads=NULL;
+
+    delete gCompactionThreads;
+    gCompactionThreads=NULL;
 
 }   // Env::Shutdown
 

--- a/util/env_posix.cc
+++ b/util/env_posix.cc
@@ -76,7 +76,7 @@ public:
         if (NULL!=ref_count_)
             inc_and_fetch(ref_count_);
 
-        // reference count of threads/paths using this object 
+        // reference count of threads/paths using this object
         //  (because there is a direct path and a threaded path usage)
         RefInc();
     };
@@ -884,9 +884,9 @@ void PosixEnv::BGThread() {
   //  has completed AND set bgthreadX_ values
   PthreadCall("lock", pthread_mutex_lock(&mu_));
   ++bgthread_count_;
-  PthreadCall(
-        "pthread_setname_np",
-        pthread_setname_np("PosixEnv::BGThread"));
+//  PthreadCall(
+//        "pthread_setname_np",
+//        pthread_setname_np("PosixEnv::BGThread"));
   PthreadCall("unlock", pthread_mutex_unlock(&mu_));
 
   while (bgthread_running_ || 0!=queue_.size()) {
@@ -908,7 +908,7 @@ void PosixEnv::BGThread() {
     else
     {
       PthreadCall("unlock", pthread_mutex_unlock(&mu_));
-    } // else        
+    } // else
   }
 
   --bgthread_count_;
@@ -1042,10 +1042,10 @@ static void InitDefaultEnv()
     gWriteThreads=new HotThreadPool(7, "RecoveryWrite",
                                     ePerfBGUnmapDirect, ePerfBGUnmapQueued,
                                     ePerfBGUnmapDequeued, ePerfBGUnmapWeighted);
-    gLevel0Threads=new HotThreadPool(7, "Level0Compact", 
+    gLevel0Threads=new HotThreadPool(7, "Level0Compact",
                                      ePerfBGLevel0Direct, ePerfBGLevel0Queued,
                                      ePerfBGLevel0Dequeued, ePerfBGLevel0Weighted);
-    gCompactionThreads=new HotThreadPool(5, "GeneralCompact", 
+    gCompactionThreads=new HotThreadPool(5, "GeneralCompact",
                                          ePerfBGCompactDirect, ePerfBGCompactQueued,
                                          ePerfBGCompactDequeued, ePerfBGCompactWeighted);
 

--- a/util/env_posix.cc
+++ b/util/env_posix.cc
@@ -1260,10 +1260,14 @@ static void InitDefaultEnv()
 
     PerformanceCounters::Init(false);
 
-    gImmThreads=new HotThreadPool(5, ePerfDebug1, ePerfDebug2,
-                                  ePerfDebug3, ePerfDebug4);
-    gWriteThreads=new HotThreadPool(7, ePerfDebug1, ePerfDebug2,
-                                    ePerfDebug3, ePerfDebug4);
+    gImmThreads=new HotThreadPool(5, ePerfBGImmDirect, ePerfBGImmQueued,
+                                  ePerfBGImmDequeued, ePerfBGImmWeighted);
+    gWriteThreads=new HotThreadPool(7, ePerfBGUnmapDirect, ePerfBGUnmapQueued,
+                                    ePerfBGUnmapDequeued, ePerfBGUnmapWeighted);
+    gLevel0Threads=new HotThreadPool(7, ePerfBGLevel0Direct, ePerfBGLevel0Queued,
+                                    ePerfBGLevel0Dequeued, ePerfBGLevel0Weighted);
+    gCompactionThreads=new HotThreadPool(5, ePerfBGCompactDirect, ePerfBGCompactQueued,
+                                    ePerfBGCompactDequeued, ePerfBGCompactWeighted);
 
     started=true;
 }
@@ -1299,6 +1303,12 @@ void Env::Shutdown()
 
     delete gWriteThreads;
     gWriteThreads=NULL;
+
+    delete gLevel0Threads;
+    gLevel0Threads=NULL;
+
+    delete gCompactionThreads;
+    gCompactionThreads=NULL;
 
 }   // Env::Shutdown
 

--- a/util/env_test.cc
+++ b/util/env_test.cc
@@ -32,6 +32,7 @@ TEST(EnvPosixTest, RunImmediately) {
   ASSERT_TRUE(called.NoBarrier_Load() != NULL);
 }
 
+#if 0 // test assumes single thread and queue. No long valid assumption
 TEST(EnvPosixTest, RunMany) {
   port::AtomicPointer last_id (NULL);
 
@@ -63,6 +64,7 @@ TEST(EnvPosixTest, RunMany) {
   void* cur = last_id.Acquire_Load();
   ASSERT_EQ(4, reinterpret_cast<uintptr_t>(cur));
 }
+#endif
 
 struct State {
   port::Mutex mu;

--- a/util/hot_threads.cc
+++ b/util/hot_threads.cc
@@ -307,8 +307,8 @@ HotThreadPool::HotThreadPool(
     enum PerformanceCountersEnum Dequeued,
     enum PerformanceCountersEnum Weighted)
     : m_PoolName((Name?Name:"")),    // this crashes if Name is NULL ...but need it set now
-      m_Shutdown(false), m_QueueThread(*this),
-      m_WorkQueueAtomic(0),
+      m_Shutdown(false), 
+      m_WorkQueueAtomic(0), m_QueueThread(*this),
       m_DirectCounter(Direct), m_QueuedCounter(Queued),
       m_DequeuedCounter(Dequeued), m_WeightedCounter(Weighted)
 {

--- a/util/hot_threads.cc
+++ b/util/hot_threads.cc
@@ -28,6 +28,10 @@
 
 #include <errno.h>
 #include <syslog.h>
+#include <sys/fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
 #include "leveldb/atomics.h"
 #include "util/hot_threads.h"
 #include "util/thread_tasks.h"
@@ -62,6 +66,8 @@ HotThread::ThreadRoutine()
     ThreadTask * submission;
 
     submission=NULL;
+
+    pthread_setname_np(m_Pool.m_PoolName.c_str());
 
     while(!m_Pool.m_Shutdown)
     {
@@ -138,12 +144,41 @@ void *QueueThreadStaticEntry(void *args)
 
 QueueThread::QueueThread(
     class HotThreadPool & Pool)
-    : m_ThreadGood(false), m_Pool(Pool)
+    : m_ThreadGood(false), m_Pool(Pool), m_SemaphorePtr(NULL)
 {
     int ret_val;
 
+    m_QueueName=m_Pool.m_PoolName;
+    m_QueueName.append("Semaphore");
+
     memset(&m_Semaphore, 0, sizeof(m_Semaphore));
     ret_val=sem_init(&m_Semaphore, 0, 0);
+
+    if (0==ret_val)
+    {
+        m_SemaphorePtr=&m_Semaphore;
+    }   // if
+
+    // retry with named semaphore
+    else if (0!=ret_val && ENOSYS==errno)
+    {
+        char pid_str[32];
+        snprintf(pid_str, sizeof(pid_str), "%d", (int)getpid());
+        m_QueueName.append(pid_str);
+
+        m_SemaphorePtr=sem_open(m_QueueName.c_str(), O_CREAT | O_EXCL, 
+                                S_IRUSR | S_IWUSR, 0);
+        // attempt delete and retry blindly
+        if (SEM_FAILED==m_SemaphorePtr)
+        {
+            sem_unlink(m_QueueName.c_str());
+            m_SemaphorePtr=sem_open(m_QueueName.c_str(), O_CREAT | O_EXCL, 
+                                    S_IRUSR | S_IWUSR, 0);
+        }   // if
+
+        // so ret_val will be zero on success
+        ret_val=(SEM_FAILED==m_SemaphorePtr);
+    }   // else if
 
     // only start this if we have a working semaphore
     if (0==ret_val)
@@ -158,13 +193,23 @@ QueueThread::QueueThread(
             syslog(LOG_ERR, "thread_create failed in QueueThread::QueueThread [%d, %m]",
                    errno);
             gPerfCounters->Inc(ePerfThreadError);
-            sem_destroy(&m_Semaphore);
+
+            if (&m_Semaphore==m_SemaphorePtr)
+            {
+                sem_destroy(&m_Semaphore);
+            }   // if
+            else
+            {
+                sem_close(m_SemaphorePtr);
+                sem_unlink(m_QueueName.c_str());
+            }   // else
+
+            m_SemaphorePtr=NULL;
         }   // else
     }   // if
     else
     {
-        // OSX currently fails with error 78, not implemented.  Fix is
-        //  to create unique names then open with sem_open
+        m_SemaphorePtr=NULL;
         syslog(LOG_ERR, "sem_init failed in QueueThread::QueueThread [%d, %m]",
                errno);
         gPerfCounters->Inc(ePerfThreadError);
@@ -181,10 +226,18 @@ QueueThread::~QueueThread()
     if (m_ThreadGood)
     {
         // release the m_QueueThread to exit
-        sem_post(&m_Semaphore);
+        sem_post(m_SemaphorePtr);
         pthread_join(m_ThreadId, NULL);
 
-        sem_destroy(&m_Semaphore);
+        if (&m_Semaphore==m_SemaphorePtr)
+        {
+            sem_destroy(&m_Semaphore);
+        }   // if
+        else
+        {
+            sem_close(m_SemaphorePtr);
+            sem_unlink(m_QueueName.c_str());
+        }   // else
     }   // if
 
     return;
@@ -201,6 +254,8 @@ QueueThread::QueueThreadRoutine()
     ThreadTask * submission;
 
     submission=NULL;
+
+    pthread_setname_np(m_QueueName.c_str());
 
     while(!m_Pool.m_Shutdown)
     {
@@ -235,7 +290,7 @@ QueueThread::QueueThreadRoutine()
         }   // if
 
         // loop until semaphore hits zero
-        sem_wait(&m_Semaphore);
+        sem_wait(m_SemaphorePtr);
 
     }   // while
 
@@ -246,11 +301,13 @@ QueueThread::QueueThreadRoutine()
 
 HotThreadPool::HotThreadPool(
     const size_t PoolSize,
+    const char * Name,
     enum PerformanceCountersEnum Direct,
     enum PerformanceCountersEnum Queued,
     enum PerformanceCountersEnum Dequeued,
     enum PerformanceCountersEnum Weighted)
-    : m_Shutdown(false), m_QueueThread(*this),
+    : m_PoolName((Name?Name:"")),    // this crashes if Name is NULL ...but need it set now
+      m_Shutdown(false), m_QueueThread(*this),
       m_WorkQueueAtomic(0),
       m_DirectCounter(Direct), m_QueuedCounter(Queued),
       m_DequeuedCounter(Dequeued), m_WeightedCounter(Weighted)
@@ -394,7 +451,7 @@ HotThreadPool::Submit(
             //   (thread not likely good on OSX)
             if (m_QueueThread.m_ThreadGood)
             {
-                ret_val=sem_post(&m_QueueThread.m_Semaphore);
+                ret_val=sem_post(m_QueueThread.m_SemaphorePtr);
                 if (0!=ret_val)
                 {
                     syslog(LOG_ERR, "sem_post failed in HotThreadPool::Submit [%d, %m]",

--- a/util/hot_threads.cc
+++ b/util/hot_threads.cc
@@ -67,7 +67,7 @@ HotThread::ThreadRoutine()
 
     submission=NULL;
 
-    pthread_setname_np(m_Pool.m_PoolName.c_str());
+//    pthread_setname_np(m_Pool.m_PoolName.c_str());
 
     while(!m_Pool.m_Shutdown)
     {
@@ -166,13 +166,13 @@ QueueThread::QueueThread(
         snprintf(pid_str, sizeof(pid_str), "%d", (int)getpid());
         m_QueueName.append(pid_str);
 
-        m_SemaphorePtr=sem_open(m_QueueName.c_str(), O_CREAT | O_EXCL, 
+        m_SemaphorePtr=sem_open(m_QueueName.c_str(), O_CREAT | O_EXCL,
                                 S_IRUSR | S_IWUSR, 0);
         // attempt delete and retry blindly
         if (SEM_FAILED==m_SemaphorePtr)
         {
             sem_unlink(m_QueueName.c_str());
-            m_SemaphorePtr=sem_open(m_QueueName.c_str(), O_CREAT | O_EXCL, 
+            m_SemaphorePtr=sem_open(m_QueueName.c_str(), O_CREAT | O_EXCL,
                                     S_IRUSR | S_IWUSR, 0);
         }   // if
 
@@ -220,7 +220,7 @@ QueueThread::QueueThread(
 }   // QueueThread::QueueThread
 
 
-QueueThread::~QueueThread() 
+QueueThread::~QueueThread()
 {
     // only clean up resources if they were started
     if (m_ThreadGood)
@@ -255,7 +255,7 @@ QueueThread::QueueThreadRoutine()
 
     submission=NULL;
 
-    pthread_setname_np(m_QueueName.c_str());
+//    pthread_setname_np(m_QueueName.c_str());
 
     while(!m_Pool.m_Shutdown)
     {

--- a/util/hot_threads.cc
+++ b/util/hot_threads.cc
@@ -35,8 +35,10 @@
 namespace leveldb {
 
 HotThreadPool * gImmThreads=NULL;
-
 HotThreadPool * gWriteThreads=NULL;
+HotThreadPool * gLevel0Threads=NULL;
+HotThreadPool * gCompactionThreads=NULL;
+
 
 
 void *ThreadStaticEntry(void *args)

--- a/util/hot_threads.h
+++ b/util/hot_threads.h
@@ -83,10 +83,12 @@ struct QueueThread
 public:
     bool m_ThreadGood;                   //!< true if thread and semaphore good
     pthread_t m_ThreadId;                //!< handle for this thread
+    std::string m_QueueName;
 
     class HotThreadPool & m_Pool;        //!< parent pool object
 
     sem_t m_Semaphore;                   //!< counts items inserted to queue
+    sem_t * m_SemaphorePtr;              //!< either &m_Semaphore or sem_open return value
 
 public:
     QueueThread(class HotThreadPool & Pool);
@@ -107,7 +109,7 @@ private:
 class HotThreadPool
 {
 public:
-
+    std::string m_PoolName;              //!< used to name threads for gdb / core
     typedef std::deque<ThreadTask*> WorkQueue_t;
     typedef std::vector<HotThread *>   ThreadPool_t;
 
@@ -126,7 +128,7 @@ public:
     enum PerformanceCountersEnum m_WeightedCounter;
 
 public:
-    HotThreadPool(const size_t thread_pool_size,
+    HotThreadPool(const size_t thread_pool_size, const char * Name,
                   enum PerformanceCountersEnum Direct,
                   enum PerformanceCountersEnum Queued,
                   enum PerformanceCountersEnum Dequeued,

--- a/util/hot_threads.h
+++ b/util/hot_threads.h
@@ -157,6 +157,8 @@ private:
 
 extern HotThreadPool * gImmThreads;
 extern HotThreadPool * gWriteThreads;
+extern HotThreadPool * gLevel0Threads;
+extern HotThreadPool * gCompactionThreads;
 
 } // namespace leveldb
 

--- a/util/hot_threads.h
+++ b/util/hot_threads.h
@@ -140,7 +140,7 @@ public:
 
     bool FindWaitingThread(ThreadTask * work);
 
-    bool Submit(ThreadTask * item);
+    bool Submit(ThreadTask * item, bool OkToQueue=true);
 
     size_t work_queue_size() const { return m_WorkQueue.size();}
     bool shutdown_pending() const  { return m_Shutdown; }

--- a/util/perf_count.cc
+++ b/util/perf_count.cc
@@ -588,7 +588,23 @@ PerformanceCounters * gPerfCounters(&LocalStartupCounters);
         "ThrottleCompacts1",
         "BGWriteError",
         "ThrottleWait",
-        "ThreadError"
+        "ThreadError",
+        "BGImmDirect",
+        "BGImmQueued",
+        "BGImmDequeued",
+        "BGImmWeighted",
+        "BGUnmapDirect",
+        "BGUnmapQueued",
+        "BGUnmapDequeued",
+        "BGUnmapWeighted",
+        "BGLevel0Direct",
+        "BGLevel0Queued",
+        "BGLevel0Dequeued",
+        "BGLevel0Weighted",
+        "BGCompactDirect",
+        "BGCompactQueued",
+        "BGCompactDequeued",
+        "BGCompactWeighted"
     };
 
 

--- a/util/perf_count.cc
+++ b/util/perf_count.cc
@@ -27,6 +27,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <syslog.h>
+#include <memory.h>
 #include <errno.h>
 
 #ifndef STORAGE_LEVELDB_INCLUDE_PERF_COUNT_H_
@@ -215,10 +216,12 @@ PerformanceCounters * gPerfCounters(&LocalStartupCounters);
         bool should_create, good;
         int ret_val, id;
         struct shmid_ds shm_info;
+        size_t open_size;
 
         ret_ptr=NULL;
         memset(&shm_info, 0, sizeof(shm_info));
         good=true;
+        open_size=sizeof(PerformanceCounters);
 
         // first id attempt, minimal request
         id=shmget(ePerfKey, 0, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
@@ -241,6 +244,12 @@ PerformanceCounters * gPerfCounters(&LocalStartupCounters);
             }   // if
         }   // if
 
+        // else open the size that exists
+        else if (0==ret_val)
+        {
+            open_size=shm_info.shm_segsz;
+        }   // else if
+
         // attempt to attach/create to shared memory instance
         if (good)
         {
@@ -251,7 +260,7 @@ PerformanceCounters * gPerfCounters(&LocalStartupCounters);
             else
                 flags = IPC_CREAT | S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH;
 
-            m_PerfSharedId=shmget(ePerfKey, sizeof(PerformanceCounters), flags);
+            m_PerfSharedId=shmget(ePerfKey, open_size, flags);
             good=(-1!=m_PerfSharedId);
         }   // if
 

--- a/util/perf_count.cc
+++ b/util/perf_count.cc
@@ -596,7 +596,15 @@ PerformanceCounters * gPerfCounters(&LocalStartupCounters);
         "BGUnmapDirect",
         "BGUnmapQueued",
         "BGUnmapDequeued",
-        "BGUnmapWeighted"
+        "BGUnmapWeighted",
+        "BGLevel0Direct",
+        "BGLevel0Queued",
+        "BGLevel0Dequeued",
+        "BGLevel0Weighted",
+        "BGCompactDirect",
+        "BGCompactQueued",
+        "BGCompactDequeued",
+        "BGCompactWeighted"
     };
 
 

--- a/util/thread_tasks.h
+++ b/util/thread_tasks.h
@@ -30,8 +30,9 @@
 
 #include <stdint.h>
 
-#include "leveldb/atomics.h"
 #include "db/db_impl.h"
+#include "db/version_set.h"
+#include "leveldb/atomics.h"
 
 namespace leveldb {
 
@@ -87,7 +88,7 @@ protected:
     DBImpl * m_DBImpl;
 
 public:
-    ImmWriteTask(DBImpl * Db)
+    explicit ImmWriteTask(DBImpl * Db)
         : m_DBImpl(Db) {};
 
     virtual ~ImmWriteTask() {};
@@ -100,6 +101,32 @@ private:
     ImmWriteTask & operator=(const ImmWriteTask &);
 
 };  // class ImmWriteTask
+
+
+/**
+ * Background compaction 
+ */
+
+class CompactionTask : public ThreadTask
+{
+protected:
+    DBImpl * m_DBImpl;
+    Compaction * m_Compaction;
+
+public:
+    CompactionTask(DBImpl * Db, Compaction * Compact)
+        : m_DBImpl(Db), m_Compaction(Compact) {};
+
+    virtual ~CompactionTask() {delete m_Compaction;};
+
+    virtual void operator()() {m_DBImpl->BackgroundCall2(m_Compaction);};
+
+private:
+    CompactionTask();
+    CompactionTask(const CompactionTask &);
+    CompactionTask & operator=(const CompactionTask &);
+
+};  // class CompactionTask
 
 } // namespace leveldb
 

--- a/util/thread_tasks.h
+++ b/util/thread_tasks.h
@@ -119,7 +119,11 @@ public:
 
     virtual ~CompactionTask() {delete m_Compaction;};
 
-    virtual void operator()() {m_DBImpl->BackgroundCall2(m_Compaction);};
+    virtual void operator()() 
+    {
+        m_DBImpl->BackgroundCall2(m_Compaction);
+        m_Compaction=NULL;
+    };
 
 private:
     CompactionTask();

--- a/util/thread_tasks.h
+++ b/util/thread_tasks.h
@@ -132,6 +132,35 @@ private:
 
 };  // class CompactionTask
 
+
+/**
+ * Original env_posix.cc task
+ */
+
+class LegacyTask : public ThreadTask
+{
+protected:
+    void (*m_Function)(void*);
+    void * m_Arg;
+
+public:
+    LegacyTask(void (*Function)(void*), void * Arg)
+        : m_Function(Function), m_Arg(Arg) {};
+
+    virtual ~LegacyTask() {};
+
+    virtual void operator()() 
+    {
+        (*m_Function)(m_Arg);
+    };
+
+private:
+    LegacyTask();
+    LegacyTask(const LegacyTask &);
+    LegacyTask & operator=(const LegacyTask &);
+
+};  // class LegacyTask
+
 } // namespace leveldb
 
 


### PR DESCRIPTION
Continuation  / conclusion of mv-hot-threads branch.  This branch addresses code review issues from mv-hot-threads (namely, creates a named semaphore for OSX that does not support unnamed … hot_threads.cc).  Two new hot thread pools complete the conversion of all previous thread queues to hot threads.  And all old threading code, google and basho, removed.  This branch contains the merge of mv-flexcache5 to enable long duration tests.
