### PR TITLE
Mv fadvise control 2.0

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -170,6 +170,9 @@ DBImpl::DBImpl(const Options& options, const std::string& dbname)
   versions_ = new VersionSet(dbname_, &options_, table_cache_,
                              &internal_comparator_);
 
+  // switch global for everyone ... tacky implementation for now
+  gFadviseWillNeed=options_.fadvise_willneed;
+
   options_.Dump(options_.info_log);
 }
 

--- a/include/leveldb/env.h
+++ b/include/leveldb/env.h
@@ -376,6 +376,8 @@ class EnvWrapper : public Env {
   Env* target_;
 };
 
+extern bool gFadviseWillNeed;
+
 }  // namespace leveldb
 
 #endif  // STORAGE_LEVELDB_INCLUDE_ENV_H_

--- a/include/leveldb/options.h
+++ b/include/leveldb/options.h
@@ -152,6 +152,10 @@ struct Options {
   // as part of a Repair operation.  Default is false
   bool is_repair;
 
+  // Riak specific flag used to indicate when fadvise() management
+  // should default to WILLNEED instead of DONTNEED.  Default is false
+  bool fadvise_willneed;
+
   // Create an Options object with default values for all fields.
   Options();
 

--- a/util/options.cc
+++ b/util/options.cc
@@ -26,7 +26,8 @@ Options::Options()
       block_restart_interval(16),
       compression(kSnappyCompression),
       filter_policy(NULL),
-      is_repair(false)
+      is_repair(false),
+      fadvise_willneed(false)
 {
 }
 
@@ -50,6 +51,7 @@ Options::Dump(
     Log(log,"           Options.compression: %d", compression);
     Log(log,"         Options.filter_policy: %s", filter_policy == NULL ? "NULL" : filter_policy->Name());
     Log(log,"             Options.is_repair: %s", is_repair ? "true" : "false");
+    Log(log,"      Options.fadvise_willneed: %s", fadvise_willneed ? "true" : "false");
     Log(log,"                        crc32c: %s", crc32c::IsHardwareCRC() ? "hardware" : "software");
 }   // Options::Dump
 


### PR DESCRIPTION
This is the customer requested feature first merged into 1.4.4.  Copied here for 2.0 integration.  

Notes on the feature are here:  https://github.com/basho/leveldb/wiki/mv-fadvise-control  

Notes from 1.4.4 pull request are here:  https://github.com/basho/leveldb/pull/110
