### PR TITLE
mv-iterator-refresh (part 2)

### DIFF
--- a/include/leveldb/options.h
+++ b/include/leveldb/options.h
@@ -216,10 +216,18 @@ struct ReadOptions {
   // Default: NULL
   const Snapshot* snapshot;
 
+  // Riak specific flag, currently used within Erlang adaptor
+  //  to enable automatic delete and new of fresh snapshot
+  //  and database iterator objects for long running iterations
+  //  (only supports iterator NEXT operations).
+  // Default: false
+  bool iterator_refresh;
+
   ReadOptions()
   : verify_checksums(true),
       fill_cache(true),
       snapshot(NULL),
+      iterator_refresh(false),
       is_compaction(false),
       env(NULL),
       info_log(NULL)


### PR DESCRIPTION
Add option for iterator_refresh, which is currently implemented in eleveldb.

Eleveldb does the following:  when an iterator is held for a long, long time AND its database (vnode) is under heavy write load, the snapshot held by the iterator can cause that database thrash.  If this iterator is ONLY processing NEXT operations, this branch will close and reopen the iterator every 5 minutes.  Intended primarily for internal Riak operations such as AAE.

Notes here: https://github.com/basho/leveldb/wiki/mv-iterator-refresh
