### PR TITLE
restore AAE exemption to writeblock size accounting in write throttle, B...

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -1565,7 +1565,7 @@ Status DBImpl::Write(const WriteOptions& options, WriteBatch* my_batch) {
       MutexLock l(&throttle_mutex_);
 
       // throttle is per key write, how many in batch?
-      count=(NULL!=my_batch ? WriteBatchInternal::Count(my_batch) : 1);
+      count=(!options_.is_internal_db && NULL!=my_batch ? WriteBatchInternal::Count(my_batch) : 1);
       env_->SleepForMicroseconds(throttle * count);
       gPerfCounters->Add(ePerfDebug0, throttle);
   }   // if

--- a/include/leveldb/options.h
+++ b/include/leveldb/options.h
@@ -152,6 +152,10 @@ struct Options {
   // as part of a Repair operation.  Default is false
   bool is_repair;
 
+  // Riak specific flag to mark Riak internal database versus
+  //  user database.  (User database gets larger cache resources.)
+  bool is_internal_db;
+
   // Riak specific flag used to indicate when fadvise() management
   // should default to WILLNEED instead of DONTNEED.  Default is false
   bool fadvise_willneed;

--- a/util/options.cc
+++ b/util/options.cc
@@ -27,6 +27,7 @@ Options::Options()
       compression(kSnappyCompression),
       filter_policy(NULL),
       is_repair(false),
+      is_internal_db(false),
       fadvise_willneed(false)
 {
 }
@@ -51,6 +52,7 @@ Options::Dump(
     Log(log,"           Options.compression: %d", compression);
     Log(log,"         Options.filter_policy: %s", filter_policy == NULL ? "NULL" : filter_policy->Name());
     Log(log,"             Options.is_repair: %s", is_repair ? "true" : "false");
+    Log(log,"        Options.is_internal_db: %s", is_internal_db ? "true" : "false");
     Log(log,"      Options.fadvise_willneed: %s", fadvise_willneed ? "true" : "false");
     Log(log,"                        crc32c: %s", crc32c::IsHardwareCRC() ? "hardware" : "software");
 }   // Options::Dump


### PR DESCRIPTION
...UT leave the accounting for 2i writeblocks.  Required back-porting of Riak 2.0 is_internal_db flag
