### PR TITLE
Mv tuning6

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -186,7 +186,7 @@ DBImpl::DBImpl(const Options& options, const std::string& dbname)
   mem_->Ref();
   has_imm_.Release_Store(NULL);
 
-  table_cache_ = new TableCache(dbname_, &options_, file_cache());
+  table_cache_ = new TableCache(dbname_, &options_, file_cache(), double_cache);
 
   versions_ = new VersionSet(dbname_, &options_, table_cache_,
                              &internal_comparator_);

--- a/db/repair.cc
+++ b/db/repair.cc
@@ -58,7 +58,7 @@ class Repairer {
         db_lock_(NULL),
         next_file_number_(1) {
     // TableCache can be small since we expect each table to be opened once.
-    table_cache_ = new TableCache(dbname_, &options_, double_cache_.GetFileCache());
+    table_cache_ = new TableCache(dbname_, &options_, double_cache_.GetFileCache(), double_cache_);
 
   }
 

--- a/db/table_cache.h
+++ b/db/table_cache.h
@@ -13,6 +13,7 @@
 #include "leveldb/cache.h"
 #include "leveldb/table.h"
 #include "port/port.h"
+#include "util/cache2.h"
 
 namespace leveldb {
 
@@ -20,7 +21,8 @@ class Env;
 
 class TableCache {
  public:
-  TableCache(const std::string& dbname, const Options* options, Cache * file_cache);
+  TableCache(const std::string& dbname, const Options* options, Cache * file_cache,
+             DoubleCache & doublecache);
   ~TableCache();
 
   // Return an iterator for the specified file number (the corresponding
@@ -66,6 +68,7 @@ class TableCache {
   const std::string dbname_;
   const Options* options_;
   Cache * cache_;
+  DoubleCache & doublecache_;
 
   Status FindTable(uint64_t file_number, uint64_t file_size, int level, Cache::Handle**, bool is_compaction=false);
 };
@@ -74,6 +77,10 @@ class TableCache {
 struct TableAndFile {
   RandomAccessFile* file;
   Table* table;
+  DoubleCache * doublecache;
+
+   TableAndFile()
+   : file(NULL), table(NULL), doublecache(NULL) {};
 };
 
 

--- a/include/leveldb/options.h
+++ b/include/leveldb/options.h
@@ -171,6 +171,11 @@ struct Options {
   //  Most recent value seen upon database open, wins.  Zero for default.
   uint64_t total_leveldb_mem;
 
+  // Riak specific option specifying block cache space that cannot
+  //  be released for page cache use.  The space may still be
+  //  released for file cache.
+  uint64_t block_cache_threshold;
+
   // Riak option to override most memory modeling and create
   //  smaller memory footprint for developers.  Helps when
   //  running large number of databases and multiple VMs. Do

--- a/include/leveldb/table.h
+++ b/include/leveldb/table.h
@@ -63,6 +63,9 @@ class Table {
   //  object in memory
   size_t TableObjectSize();
 
+  // riak routine to retrieve disk size of table file
+  uint64_t GetFileSize();
+
   // access routines for testing tools, not for public use
   Block * TEST_GetIndexBlock();
   size_t TEST_TableObjectSize() {return(TableObjectSize());};

--- a/table/table.cc
+++ b/table/table.cc
@@ -28,6 +28,7 @@ struct Table::Rep {
   Options options;
   Status status;
   RandomAccessFile* file;
+  uint64_t file_size;
   uint64_t cache_id;
   FilterBlockReader* filter;
   const char* filter_data;
@@ -77,6 +78,7 @@ Status Table::Open(const Options& options,
     Rep* rep = new Table::Rep;
     rep->options = options;
     rep->file = file;
+    rep->file_size = size;
     rep->metaindex_handle = footer.metaindex_handle();
     rep->index_block = index_block;
     rep->cache_id = (options.block_cache ? options.block_cache->NewId() : 0);
@@ -366,6 +368,13 @@ uint64_t Table::ApproximateOffsetOf(const Slice& key) const {
   delete index_iter;
   return result;
 }
+
+
+uint64_t 
+Table::GetFileSize()
+{
+    return(rep_->file_size);
+};
 
 Block *
 Table::TEST_GetIndexBlock() {return(rep_->index_block);};

--- a/tools/sst_scan.cc
+++ b/tools/sst_scan.cc
@@ -94,7 +94,7 @@ main(
             meta.number=strtol(table_name.c_str(), NULL, 10);
 
             options.filter_policy=leveldb::NewBloomFilterPolicy(10);
-            table_cache=new leveldb::TableCache(dbname, &options, double_cache.GetFileCache());
+            table_cache=new leveldb::TableCache(dbname, &options, double_cache.GetFileCache(), double_cache);
             table_name = leveldb::TableFileName(dbname, meta.number, search_level);
 
             // open table, step 1 get file size

--- a/util/cache2.h
+++ b/util/cache2.h
@@ -73,6 +73,8 @@ protected:
     size_t m_TotalAllocation;
     time_t m_FileTimeout;       //!< seconds to allow file to stay cached.  default 4 days.
 
+    uint64_t m_BlockCacheThreshold; //!< from Options, point where block cache canNOT be
+                                    //!< sacrificed for page cache
     volatile uint64_t m_SizeCachedFiles; //!< disk size of .sst files in file cache
 
 private:

--- a/util/cache2.h
+++ b/util/cache2.h
@@ -24,6 +24,7 @@
 #define STORAGE_LEVELDB_INCLUDE_CACHE2_H_
 
 #include <stdint.h>
+#include "leveldb/atomics.h"
 #include "leveldb/cache.h"
 #include "leveldb/options.h"
 #include "leveldb/slice.h"
@@ -59,6 +60,9 @@ public:
 
     bool IsInternalDB() const {return(m_IsInternalDB);};
 
+    void AddFileSize(uint64_t file_size) {add_and_fetch(&m_SizeCachedFiles, file_size);};
+    void SubFileSize(uint64_t file_size) {sub_and_fetch(&m_SizeCachedFiles, file_size);};
+
 protected:
     ShardedLRUCache2 * m_FileCache;   //!< file cache used by db/tablecache.cc
     ShardedLRUCache2 * m_BlockCache;  //!< used by table/table.cc
@@ -68,6 +72,8 @@ protected:
     size_t m_Overhead;          //!< reduce from allocation to better estimate limits
     size_t m_TotalAllocation;
     time_t m_FileTimeout;       //!< seconds to allow file to stay cached.  default 4 days.
+
+    volatile uint64_t m_SizeCachedFiles; //!< disk size of .sst files in file cache
 
 private:
     DoubleCache();                       //!< no default constructor

--- a/util/options.cc
+++ b/util/options.cc
@@ -35,7 +35,7 @@ Options::Options()
       is_repair(false),
       is_internal_db(false),
       total_leveldb_mem(0),
-      block_cache_threshold(16<<20),
+      block_cache_threshold(32<<20),
       limited_developer_mem(false),
       delete_threshold(1000),
       fadvise_willneed(false)

--- a/util/options.cc
+++ b/util/options.cc
@@ -35,6 +35,7 @@ Options::Options()
       is_repair(false),
       is_internal_db(false),
       total_leveldb_mem(0),
+      block_cache_threshold(16<<20),
       limited_developer_mem(false),
       delete_threshold(1000),
       fadvise_willneed(false)
@@ -64,6 +65,7 @@ Options::Dump(
     Log(log,"             Options.is_repair: %s", is_repair ? "true" : "false");
     Log(log,"        Options.is_internal_db: %s", is_internal_db ? "true" : "false");
     Log(log,"     Options.total_leveldb_mem: %" PRIu64, total_leveldb_mem);
+    Log(log," Options.block_cache_threshold: %" PRIu64, block_cache_threshold);
     Log(log," Options.limited_developer_mem: %s", limited_developer_mem ? "true" : "false");
     Log(log,"      Options.delete_threshold: %" PRIu64, delete_threshold);
     Log(log,"      Options.fadvise_willneed: %s", fadvise_willneed ? "true" : "false");


### PR DESCRIPTION
Detailed discussion here:  https://github.com/basho/leveldb/wiki/mv-tuning6

Creates limit on size of block cache based upon estimated optimal size for page cache.
