### PR TITLE
Mmap size option

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -132,9 +132,11 @@ Options SanitizeOptions(const std::string& dbname,
   if (src.limited_developer_mem)
   {
       gMapSize=2*1024*1024L;
-      if (2*1024*1024L < result.write_buffer_size) // let unit tests be smaller
-          result.write_buffer_size=2*1024*1024L;
+  } else if (src.mmap_size) {
+      gMapSize=src.mmap_size;
   }   // if
+  if (gMapSize < result.write_buffer_size) // let unit tests be smaller
+      result.write_buffer_size=gMapSize;
 
   if (result.info_log == NULL) {
     // Open a log file in the same directory as the db

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -129,10 +129,9 @@ Options SanitizeOptions(const std::string& dbname,
   ClipToRange(&result.write_buffer_size,         64<<10, 1<<30);
   ClipToRange(&result.block_size,                1<<10,  4<<20);
 
-  if (src.limited_developer_mem)
-  {
-      gMapSize=2*1024*1024L;
-  } else if (src.mmap_size) {
+  // This was limited_developper_mem before, it set the gMapSize to
+  // 
+  if (src.mmap_size) {
       gMapSize=src.mmap_size;
   }   // if
   if (gMapSize < result.write_buffer_size) // let unit tests be smaller

--- a/include/leveldb/options.h
+++ b/include/leveldb/options.h
@@ -171,6 +171,9 @@ struct Options {
   //  Most recent value seen upon database open, wins.  Zero for default.
   uint64_t total_leveldb_mem;
 
+  // The size of each MMAped file, choose 0 for the default (20M)
+  uint64_t mmap_size;
+
   // Riak specific option specifying block cache space that cannot
   //  be released for page cache use.  The space may still be
   //  released for file cache.

--- a/util/env_posix.cc
+++ b/util/env_posix.cc
@@ -45,7 +45,11 @@
 
 namespace leveldb {
 
-volatile size_t gMapSize=20*1024*1024L;
+// FiFo 20M is way to much for having multiple files :(
+// lets go down to 1
+//volatile size_t gMapSize=20*1024*1024L;
+
+volatile size_t gMapSize=1024*1024L;
 
 // ugly global used to change fadvise behaviour
 bool gFadviseWillNeed=false;

--- a/util/env_posix.cc
+++ b/util/env_posix.cc
@@ -47,9 +47,9 @@ namespace leveldb {
 
 // FiFo 20M is way to much for having multiple files :(
 // lets go down to 1
-//volatile size_t gMapSize=20*1024*1024L;
+volatile size_t gMapSize=20*1024*1024L;
 
-volatile size_t gMapSize=1024*1024L;
+  // volatile size_t gMapSize=1024*1024L;
 
 // ugly global used to change fadvise behaviour
 bool gFadviseWillNeed=false;

--- a/util/env_posix.cc
+++ b/util/env_posix.cc
@@ -43,17 +43,11 @@
 #define HAVE_FADVISE
 #endif
 
-// #define DFLT_MMAP_SIZE 20*1024*1024L
-// This is for fifo untill I fixed the dynamic setting
-#define DFLT_MMAP_SIZE 1024*1024L
+#define DFLT_MMAP_SIZE 20*1024*1024L
 
 namespace leveldb {
 
-// FiFo 20M is way to much for having multiple files :(
-// lets go down to 1
 volatile size_t gMapSize=DFLT_MMAP_SIZE;
-
-  // volatile size_t gMapSize=1024*1024L;
 
 // ugly global used to change fadvise behaviour
 bool gFadviseWillNeed=false;

--- a/util/env_posix.cc
+++ b/util/env_posix.cc
@@ -43,11 +43,15 @@
 #define HAVE_FADVISE
 #endif
 
+// #define DFLT_MMAP_SIZE 20*1024*1024L
+// This is for fifo untill I fixed the dynamic setting
+#define DFLT_MMAP_SIZE 1024*1024L
+
 namespace leveldb {
 
 // FiFo 20M is way to much for having multiple files :(
 // lets go down to 1
-volatile size_t gMapSize=20*1024*1024L;
+volatile size_t gMapSize=DFLT_MMAP_SIZE;
 
   // volatile size_t gMapSize=1024*1024L;
 

--- a/util/options.cc
+++ b/util/options.cc
@@ -36,6 +36,7 @@ Options::Options()
       is_internal_db(false),
       total_leveldb_mem(0),
       block_cache_threshold(32<<20),
+      mmap_size(0),
       limited_developer_mem(false),
       delete_threshold(1000),
       fadvise_willneed(false)
@@ -66,6 +67,7 @@ Options::Dump(
     Log(log,"        Options.is_internal_db: %s", is_internal_db ? "true" : "false");
     Log(log,"     Options.total_leveldb_mem: %" PRIu64, total_leveldb_mem);
     Log(log," Options.block_cache_threshold: %" PRIu64, block_cache_threshold);
+    Log(log,"             Options.mmap_size: %" PRIu64, mmap_size);
     Log(log," Options.limited_developer_mem: %s", limited_developer_mem ? "true" : "false");
     Log(log,"      Options.delete_threshold: %" PRIu64, delete_threshold);
     Log(log,"      Options.fadvise_willneed: %s", fadvise_willneed ? "true" : "false");


### PR DESCRIPTION
This pull requests add the mmap_size option to the options passable to the levedb instance. This is a more general approach to the developer_limit_memory flag which gives the developer control over how much space mmaped files will take. This is especially important in either development situates (as a substitution for developer_limit_memory) or when instead of one big leveldb file the application already spreads them around - it also allows to reserve bigger chunks then 20MB if it is helpful for the system.
