### PR TITLE
activate the AssertHeld() logic of Mutex and Spin classes. And address issue #100

### DIFF
--- a/db/memtable.cc
+++ b/db/memtable.cc
@@ -101,7 +101,7 @@ void MemTable::Add(SequenceNumber s, ValueType type,
   p += 8;
   p = EncodeVarint32(p, val_size);
   memcpy(p, value.data(), val_size);
-  assert((p + val_size) - buf == encoded_len);
+  assert((size_t)((p + val_size) - buf) == encoded_len);
   table_.Insert(buf);
 }
 

--- a/port/port_posix.h
+++ b/port/port_posix.h
@@ -9,6 +9,7 @@
 
 // to properly pull in bits/posix_opt.h on Linux
 #include <unistd.h>
+#include <assert.h>
 
 #undef PLATFORM_IS_LITTLE_ENDIAN
 #if defined(OS_MACOSX)
@@ -94,7 +95,7 @@ class Mutex {
 
   void Lock();
   void Unlock();
-  void AssertHeld() { }
+  void AssertHeld() {assert(0!=pthread_mutex_trylock(&mu_));}
 
  private:
   friend class CondVar;
@@ -114,7 +115,7 @@ class Spin {
 
   void Lock();
   void Unlock();
-  void AssertHeld() { }
+  void AssertHeld() {assert(0!=pthread_spin_trylock(&sp_));}
 
  private:
   friend class CondVar;


### PR DESCRIPTION
Scary to find that Mutex.AssertHeld() test, used throughout the leveldb code, performs no test.  This adds the necessary assert logic.  PR is for post-Riak 2.0 code freeze.

I used this code on a really long Bulk test sequence.  It did not find any mutex problems … thankfully.

This branch also contains an adjustment to VersionSet::LogAndApply().  Scott Fritchie created a test to randomly fail fail accesses.  That test found a flaw in the LogAndApply() logic flow that was adjusted for 2.0.  The logic flow now correctly differentiates between file failures and write failures … i.e. does not segfault.
