### PR TITLE
Mv tiered options

### DIFF
--- a/db/builder.cc
+++ b/db/builder.cc
@@ -36,7 +36,7 @@ Status BuildTable(const std::string& dbname,
 
   KeyRetirement retire(user_comparator, smallest_snapshot);
 
-  std::string fname = TableFileName(dbname, meta->number, meta->level);
+  std::string fname = TableFileName(options, meta->number, meta->level);
   if (iter->Valid()) {
     WritableFile* file;
     s = env->NewWritableFile(fname, &file);

--- a/db/corruption_test.cc
+++ b/db/corruption_test.cc
@@ -36,6 +36,7 @@ class CorruptionTest {
     tiny_cache_ = NewLRUCache(100);
     options_.env = &env_;
     dbname_ = test::TmpDir() + "/db_test";
+    dbname_ = MakeTieredDbname(dbname_, options_);
     DestroyDB(dbname_, options_);
 
     db_ = NULL;
@@ -122,7 +123,7 @@ class CorruptionTest {
     if (leveldb::kTableFile!=filetype)
         dirname=dbname_;
     else
-        dirname=MakeDirName2(dbname_, level, "sst");
+        dirname=MakeDirName2(options_, level, "sst");
 
     ASSERT_OK(env_.GetChildren(dirname, &filenames));
 

--- a/db/filename.cc
+++ b/db/filename.cc
@@ -47,7 +47,7 @@ static std::string MakeFileName2(const Options & options, uint64_t number,
                static_cast<unsigned long long>(number),
                suffix);
 
-  return((level<options.tiered_slow_level ?
+  return((level<(int)options.tiered_slow_level ?
           options.tiered_fast_prefix : options.tiered_slow_prefix) + buf);
 }
 
@@ -61,7 +61,7 @@ std::string MakeDirName2(const Options & options,
       snprintf(buf, sizeof(buf), "/%s",
                suffix);
 
-  return((level<options.tiered_slow_level ?
+  return((level<(int)options.tiered_slow_level ?
           options.tiered_fast_prefix : options.tiered_slow_prefix) + buf);
 }
 
@@ -247,7 +247,7 @@ MakeTieredDbname(
     const std::string & dbname,    // input ... original dbname from DBImpl constructor
     Options & options)             // input/output ... writable Options, tiered values changed
 {
-    if (0<options.tiered_slow_level && options.tiered_slow_level<config::kNumLevels
+    if (0<(int)options.tiered_slow_level && (int)options.tiered_slow_level<config::kNumLevels
         && 0!=options.tiered_fast_prefix.size() && 0!=options.tiered_slow_prefix.size())
     {
         options.tiered_fast_prefix.append("/");

--- a/db/filename.cc
+++ b/db/filename.cc
@@ -29,7 +29,7 @@ static std::string MakeFileName(const std::string& name, uint64_t number,
   return name + buf;
 }
 
-static std::string MakeFileName2(const std::string& name, uint64_t number,
+static std::string MakeFileName2(const Options & options, uint64_t number,
                                  int level, const char* suffix) {
   char buf[100];
   if (0<=level)
@@ -47,11 +47,12 @@ static std::string MakeFileName2(const std::string& name, uint64_t number,
                static_cast<unsigned long long>(number),
                suffix);
 
-  return name + buf;
+  return((level<options.tiered_slow_level ?
+          options.tiered_fast_prefix : options.tiered_slow_prefix) + buf);
 }
 
-std::string MakeDirName2(const std::string& name,
-                                 int level, const char* suffix) {
+std::string MakeDirName2(const Options & options,
+                         int level, const char* suffix) {
   char buf[100];
   if (-1!=level)
       snprintf(buf, sizeof(buf), "/%s_%-d",
@@ -60,7 +61,8 @@ std::string MakeDirName2(const std::string& name,
       snprintf(buf, sizeof(buf), "/%s",
                suffix);
 
-  return name + buf;
+  return((level<options.tiered_slow_level ?
+          options.tiered_fast_prefix : options.tiered_slow_prefix) + buf);
 }
 
 std::string LogFileName(const std::string& name, uint64_t number) {
@@ -68,9 +70,9 @@ std::string LogFileName(const std::string& name, uint64_t number) {
   return MakeFileName(name, number, "log");
 }
 
-std::string TableFileName(const std::string& name, uint64_t number, int level) {
+std::string TableFileName(const Options & options, uint64_t number, int level) {
   assert(number > 0);
-  return MakeFileName2(name, number, level, "sst");
+  return MakeFileName2(options, number, level, "sst");
 }
 
 std::string DescriptorFileName(const std::string& dbname, uint64_t number) {
@@ -177,7 +179,7 @@ Status SetCurrentFile(Env* env, const std::string& dbname,
 
 
 Status
-MakeLevelDirectories(Env * env, const std::string & dbname)
+MakeLevelDirectories(Env * env, const Options & options)
 {
     Status ret_stat;
     int level;
@@ -185,7 +187,7 @@ MakeLevelDirectories(Env * env, const std::string & dbname)
 
     for (level=0; level<config::kNumLevels && ret_stat.ok(); ++level)
     {
-        dirname=MakeDirName2(dbname, level, "sst");
+        dirname=MakeDirName2(options, level, "sst");
 
         // ignoring error since no way to tell if "bad" error, or "already exists" error
         env->CreateDir(dirname.c_str());
@@ -199,7 +201,7 @@ MakeLevelDirectories(Env * env, const std::string & dbname)
 bool
 TestForLevelDirectories(
     Env * env,
-    const std::string & dbname,
+    const Options & options,
     Version * version)
 {
     bool ret_flag, again;
@@ -215,7 +217,7 @@ TestForLevelDirectories(
         again=false;
 
         // does directory exist
-        dirname=MakeDirName2(dbname, level, "sst");
+        dirname=MakeDirName2(options, level, "sst");
         ret_flag=env->FileExists(dirname.c_str());
 
         // do all files exist in level
@@ -228,7 +230,7 @@ TestForLevelDirectories(
 
             for (it=level_files.begin(); level_files.end()!=it && ret_flag; ++it)
             {
-                table_name=TableFileName(dbname, (*it)->number, level);
+                table_name=TableFileName(options, (*it)->number, level);
                 ret_flag=env->FileExists(table_name.c_str());
             }   // for
 
@@ -239,5 +241,30 @@ TestForLevelDirectories(
     return(ret_flag);
 
 }   // TestForLevelDirectories
+
+std::string       // replacement dbname ... potentially tiered
+MakeTieredDbname(
+    const std::string & dbname,    // input ... original dbname from DBImpl constructor
+    Options & options)             // input/output ... writable Options, tiered values changed
+{
+    if (0<options.tiered_slow_level && options.tiered_slow_level<config::kNumLevels
+        && 0!=options.tiered_fast_prefix.size() && 0!=options.tiered_slow_prefix.size())
+    {
+        options.tiered_fast_prefix.append("/");
+        options.tiered_fast_prefix.append(dbname);
+
+        options.tiered_slow_prefix.append("/");
+        options.tiered_slow_prefix.append(dbname);
+    }
+    else
+    {
+        options.tiered_slow_level=0;
+        options.tiered_fast_prefix=dbname; // duplicate as is
+        options.tiered_slow_prefix=dbname;
+    }   // else
+
+    return(options.tiered_fast_prefix);
+
+}   // MakeTieredDbname
 
 }  // namespace leveldb

--- a/db/filename.h
+++ b/db/filename.h
@@ -9,6 +9,7 @@
 
 #include <stdint.h>
 #include <string>
+#include "leveldb/options.h"
 #include "leveldb/slice.h"
 #include "leveldb/status.h"
 #include "port/port.h"
@@ -28,13 +29,19 @@ enum FileType {
   kInfoLogFile  // Either the current one, or an old one
 };
 
-
-std::string MakeDirName2(const std::string& name,
+// Riak specific routine to help create sst_? subdirectory names
+std::string MakeDirName2(const Options & options,
                          int level, const char* suffix);
 
-Status MakeLevelDirectories(Env * env, const std::string & dbname);
+// Riak specific routine to help create sst_? subdirectories
+Status MakeLevelDirectories(Env * env, const Options & options);
 
-bool TestForLevelDirectories(Env * env, const std::string & dbname, class Version *);
+// Riak specific routine to test if sst_? subdirectories exist
+bool TestForLevelDirectories(Env * env, const Options & options, class Version *);
+
+// Riak specific routine to standardize conversion of dbname and
+//  Options' tiered directories (options parameter is MODIFIED)
+std::string MakeTieredDbname(const std::string &dbname, Options & options_rw);
 
 // Return the name of the log file with the specified number
 // in the db named by "dbname".  The result will be prefixed with
@@ -44,7 +51,8 @@ extern std::string LogFileName(const std::string& dbname, uint64_t number);
 // Return the name of the sstable with the specified number
 // in the db named by "dbname".  The result will be prefixed with
 // "dbname".
-extern std::string TableFileName(const std::string& dbname, uint64_t number, int level);
+extern std::string TableFileName(const Options & options, uint64_t number,
+                                 int level);
 
 // Return the name of the descriptor file for the db named by
 // "dbname" and the specified incarnation number.  The result will be
@@ -74,7 +82,7 @@ extern std::string OldInfoLogFileName(const std::string& dbname);
 // If filename is a leveldb file, store the type of the file in *type.
 // The number encoded in the filename is stored in *number.  If the
 // filename was successfully parsed, returns true.  Else return false.
-extern bool ParseFileName(const std::string& filename,
+extern bool ParseFileName(const std::string& tiered_filename,
                           uint64_t* number,
                           FileType* type);
 

--- a/db/filename_test.cc
+++ b/db/filename_test.cc
@@ -77,6 +77,7 @@ TEST(FileNameTest, Construction) {
   uint64_t number;
   FileType type;
   std::string fname;
+  Options options;
 
   fname = CurrentFileName("foo");
   ASSERT_EQ("foo/", std::string(fname.data(), 4));
@@ -96,12 +97,39 @@ TEST(FileNameTest, Construction) {
   ASSERT_EQ(192, number);
   ASSERT_EQ(kLogFile, type);
 
-  fname = TableFileName("bar", 200, 1);
+  options.tiered_fast_prefix="bar";
+  options.tiered_slow_prefix="bar";
+  fname = TableFileName(options, 200, 1);
   ASSERT_EQ("bar/", std::string(fname.data(), 4));
   ASSERT_EQ("sst_1/", std::string(fname.substr(4,6)));
   ASSERT_TRUE(ParseFileName(fname.c_str() + 10, &number, &type));
   ASSERT_EQ(200, number);
   ASSERT_EQ(kTableFile, type);
+
+  fname = TableFileName(options, 400, 4);
+  ASSERT_EQ("bar/", std::string(fname.data(), 4));
+  ASSERT_EQ("sst_4/", std::string(fname.substr(4,6)));
+  ASSERT_TRUE(ParseFileName(fname.c_str() + 10, &number, &type));
+  ASSERT_EQ(400, number);
+  ASSERT_EQ(kTableFile, type);
+
+  options.tiered_slow_level=4;
+  options.tiered_fast_prefix="fast";
+  options.tiered_slow_prefix="slow";
+  fname = TableFileName(options, 500, 3);
+  ASSERT_EQ("fast/", std::string(fname.data(), 5));
+  ASSERT_EQ("sst_3/", std::string(fname.substr(5,6)));
+  ASSERT_TRUE(ParseFileName(fname.c_str() + 11, &number, &type));
+  ASSERT_EQ(500, number);
+  ASSERT_EQ(kTableFile, type);
+
+  fname = TableFileName(options, 600, 4);
+  ASSERT_EQ("slow/", std::string(fname.data(), 5));
+  ASSERT_EQ("sst_4/", std::string(fname.substr(5,6)));
+  ASSERT_TRUE(ParseFileName(fname.c_str() + 11, &number, &type));
+  ASSERT_EQ(600, number);
+  ASSERT_EQ(kTableFile, type);
+
 
   fname = DescriptorFileName("bar", 100);
   ASSERT_EQ("bar/", std::string(fname.data(), 4));

--- a/db/table_cache.cc
+++ b/db/table_cache.cc
@@ -50,7 +50,7 @@ Status TableCache::FindTable(uint64_t file_number, uint64_t file_size, int level
   Slice key(buf, sizeof(buf));
   *handle = cache_->Lookup(key);
   if (*handle == NULL) {
-    std::string fname = TableFileName(dbname_, file_number, level);
+    std::string fname = TableFileName(*options_, file_number, level);
     RandomAccessFile* file = NULL;
     Table* table = NULL;
     s = env_->NewRandomAccessFile(fname, &file);

--- a/include/leveldb/options.h
+++ b/include/leveldb/options.h
@@ -193,6 +193,27 @@ struct Options {
   // should default to WILLNEED instead of DONTNEED.  Default is false
   bool fadvise_willneed;
 
+  // *****
+  // Riak specific options for establishing two tiers of disk arrays.
+  // All three tier options must be valid for the option to activate.
+  // When active, leveldb directories are constructed using either
+  // the fast or slow prefix followed by the database name given
+  // in the DB::Open call.  (a synonym for "prefix" is "mount")
+  // *****
+
+  // Riak specific option setting the level number at which the
+  // "tiered_slow_prefix" should be used.  Default is zero which
+  // disables the option.  Valid values are 1 to 6.  3 or 4 recommended.
+  unsigned tiered_slow_level;
+
+  // Riak specific option with the path prefix used for "fast" disk
+  // array.  levels 0 to tiered_slow_level-1 use this path prefix
+  std::string tiered_fast_prefix;
+
+  // Riak specific option with the path prefix used for "slow" disk
+  // array.  levels tiered_slow_level through 6 use this path prefix
+  std::string tiered_slow_prefix;
+
   // Create an Options object with default values for all fields.
   Options();
 

--- a/tools/sst_scan.cc
+++ b/tools/sst_scan.cc
@@ -89,13 +89,14 @@ main(
             // make copy since basename() and dirname() may modify
             path_temp=*cursor;
             dbname=dirname((char *)path_temp.c_str());
+            dbname=MakeTieredDbname(dbname, options);
             path_temp=*cursor;
             table_name=basename((char *)path_temp.c_str());
             meta.number=strtol(table_name.c_str(), NULL, 10);
 
             options.filter_policy=leveldb::NewBloomFilterPolicy(10);
             table_cache=new leveldb::TableCache(dbname, &options, double_cache.GetFileCache(), double_cache);
-            table_name = leveldb::TableFileName(dbname, meta.number, search_level);
+            table_name = leveldb::TableFileName(options, meta.number, search_level);
 
             // open table, step 1 get file size
             leveldb::Status status = env->GetFileSize(table_name, &meta.file_size);

--- a/util/options.cc
+++ b/util/options.cc
@@ -38,7 +38,8 @@ Options::Options()
       block_cache_threshold(32<<20),
       limited_developer_mem(false),
       delete_threshold(1000),
-      fadvise_willneed(false)
+      fadvise_willneed(false),
+      tiered_slow_level(0)
 {
 }
 
@@ -69,6 +70,9 @@ Options::Dump(
     Log(log," Options.limited_developer_mem: %s", limited_developer_mem ? "true" : "false");
     Log(log,"      Options.delete_threshold: %" PRIu64, delete_threshold);
     Log(log,"      Options.fadvise_willneed: %s", fadvise_willneed ? "true" : "false");
+    Log(log,"     Options.tiered_slow_level: %d", tiered_slow_level);
+    Log(log,"    Options.tiered_fast_prefix: %s", tiered_fast_prefix.c_str());
+    Log(log,"    Options.tiered_slow_prefix: %s", tiered_slow_prefix.c_str());
     Log(log,"                        crc32c: %s", crc32c::IsHardwareCRC() ? "hardware" : "software");
 }   // Options::Dump
 


### PR DESCRIPTION
Add options necessary to support tiered storage based upon the sst_? directories (introduced in Riak 1.3).

Branch discussion is here:
   https://github.com/basho/leveldb/wiki/mv-tiered-options
