### PR TITLE
code to isolate Log() file flushes from happening within mutex...

### DIFF
--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1259,11 +1259,19 @@ VersionSet::UpdatePenalty(
             const uint64_t level_bytes = TotalFileSize(v->files_[level]);
 
             if (config::kNumOverlapLevels!=level)
+            {
                 penalty_score = static_cast<double>(level_bytes) / gLevelTraits[level].m_MaxBytesForLevel;
 
+                // penalty needs to be non-linear once it exceeds 1.0 (especially for tiered storage).
+                //  original values of penalty_score below one are not relevant, hence square of less than one
+                //  is equally ignored.
+                penalty_score *= penalty_score;
+            }   // if
             // first sort layer needs to clear before next dump of overlapped files.
             else
+            {
                 penalty_score = (1<(static_cast<double>(level_bytes) / gLevelTraits[level].m_DesiredBytesForLevel)? 1.0 : 0);
+            }   // else
 
             if (1.0<=penalty_score)
                 penalty+=(static_cast<int>(penalty_score));
@@ -1277,7 +1285,7 @@ VersionSet::UpdatePenalty(
 
     v->write_penalty_ = penalty;
 
-    Log(options_->info_log,"UpdatePenalty: %d", penalty);
+// mutex_ held.    Log(options_->info_log,"UpdatePenalty: %d", penalty);
 
     return;
 
@@ -1647,6 +1655,7 @@ void VersionSet::SetupOtherInputs(Compaction* c) {
               current_->GetOverlappingInputs(level+1, &new_start, &new_limit,
                                              &expanded1);
               if (expanded1.size() == c->inputs_[1].size()) {
+#if 0  // mutex_ held
                   Log(options_->info_log,
                       "Expanding@%d %d+%d (%ld+%ld bytes) to %d+%d (%ld+%ld bytes)\n",
                       level,
@@ -1656,6 +1665,7 @@ void VersionSet::SetupOtherInputs(Compaction* c) {
                       int(expanded0.size()),
                       int(expanded1.size()),
                       long(expanded0_size), long(inputs1_size));
+#endif
                   smallest = new_start;
                   largest = new_limit;
                   c->inputs_[0] = expanded0;
@@ -1853,7 +1863,7 @@ bool Compaction::ShouldStopBefore(const Slice& internal_key, size_t key_count) {
     //  to meet file open speed goals
     else
     {
-      ret_flag=(75000<key_count);
+      ret_flag=(300000<key_count);
      } // else
   }  // if
 

--- a/util/cache2.cc
+++ b/util/cache2.cc
@@ -432,7 +432,7 @@ DoubleCache::DoubleCache(
     : m_FileCache(NULL), m_BlockCache(NULL),
       m_IsInternalDB(options.is_internal_db), m_PlentySpace(true),
       m_Overhead(0), m_TotalAllocation(0),
-      m_FileTimeout(4*24*60*60),  // default is 4 days
+      m_FileTimeout(10*24*60*60),  // default is 10 days
       m_BlockCacheThreshold(options.block_cache_threshold),
       m_SizeCachedFiles(0)
 {
@@ -598,7 +598,7 @@ Cache::Handle* LRUCache2::Lookup(const Slice& key, uint32_t hash) {
     LRU_Remove(e);
     LRU_Append(e);
 
-    // establish time limit on files in file cache (like 4 days)
+    // establish time limit on files in file cache (like 10 days)
     //  so they do not go stale and steal from block cache
     if (is_file_cache_)
     {
@@ -652,7 +652,7 @@ Cache::Handle* LRUCache2::Insert(
     e->expire_seconds=0;
     memcpy(e->key_data, key.data(), key.size());
 
-    // establish time limit on files in file cache (like 4 days)
+    // establish time limit on files in file cache (like 10 days)
     //  so they do not go stale and steal from block cache
     if (is_file_cache_)
     {

--- a/util/posix_logger.h
+++ b/util/posix_logger.h
@@ -13,7 +13,6 @@
 #include <sys/time.h>
 #include <time.h>
 #include "leveldb/env.h"
-#include "util/mutexlock.h"
 
 namespace leveldb {
 
@@ -21,7 +20,6 @@ class PosixLogger : public Logger {
  private:
   FILE* file_;
   uint64_t (*gettid_)();  // Return the thread id for the current thread
-  port::Spin spin_;
 
  public:
   PosixLogger(FILE* f, uint64_t (*gettid)()) : file_(f), gettid_(gettid) { }
@@ -86,11 +84,7 @@ class PosixLogger : public Logger {
       }
 
       assert(p <= limit);
-      // make fwrite single threaded (not fflush!)
-      {
-         SpinLock lock(&spin_);
-         fwrite(base, 1, p - base, file_);
-      }
+      fwrite(base, 1, p - base, file_);
       fflush(file_);
       if (base != buffer) {
         delete[] base;


### PR DESCRIPTION
..._ locked regions.  Same with clean-up file deletes.

Detail discussion here: https://github.com/basho/leveldb/wiki/mv-mutex-cleanup
