### PR TITLE
Mv write sizing

### DIFF
--- a/db/builder.cc
+++ b/db/builder.cc
@@ -39,16 +39,9 @@ Status BuildTable(const std::string& dbname,
   std::string fname = TableFileName(options, meta->number, meta->level);
   if (iter->Valid()) {
     WritableFile* file;
-    size_t map_size;
 
-    // large buffers, try for a little bit bigger than half hoping
-    //  for two writes ... not three
-    if (10*1024*1024 < options.write_buffer_size)
-        map_size=(options.write_buffer_size/6)*4;
-    else
-        map_size=(options.write_buffer_size*12)/10;  // integer multiply 1.2
-
-    s = env->NewWritableFile(fname, &file, map_size);
+    s = env->NewWritableFile(fname, &file,
+                                 env->RecoveryMmapSize(&options));
     if (!s.ok()) {
       return s;
     }

--- a/db/builder.cc
+++ b/db/builder.cc
@@ -39,7 +39,16 @@ Status BuildTable(const std::string& dbname,
   std::string fname = TableFileName(options, meta->number, meta->level);
   if (iter->Valid()) {
     WritableFile* file;
-    s = env->NewWritableFile(fname, &file);
+    size_t map_size;
+
+    // large buffers, try for a little bit bigger than half hoping
+    //  for two writes ... not three
+    if (10*1024*1024 < options.write_buffer_size)
+        map_size=(options.write_buffer_size/6)*4;
+    else
+        map_size=(options.write_buffer_size*12)/10;  // integer multiply 1.2
+
+    s = env->NewWritableFile(fname, &file, map_size);
     if (!s.ok()) {
       return s;
     }

--- a/db/corruption_test.cc
+++ b/db/corruption_test.cc
@@ -222,7 +222,9 @@ TEST(CorruptionTest, NewFileErrorDuringWrite) {
   const int num = 3 + (Options().write_buffer_size / kValueSize);
   std::string value_storage;
   Status s;
-  for (int i = 0; s.ok() && i < num; i++) {
+  for (int i = 0; 
+       s.ok() && i < num && 0==env_.num_writable_file_errors_; 
+       i++) {
     WriteBatch batch;
     batch.Put("a", Value(100, &value_storage));
     s = db_->Write(WriteOptions(), &batch);

--- a/db/db_bench.cc
+++ b/db/db_bench.cc
@@ -908,7 +908,7 @@ class Benchmark {
     char fname[100];
     snprintf(fname, sizeof(fname), "%s/heap-%04d", FLAGS_db, ++heap_counter_);
     WritableFile* file;
-    Status s = Env::Default()->NewWritableFile(fname, &file);
+    Status s = Env::Default()->NewWritableFile(fname, &file, 2<<20);
     if (!s.ok()) {
       fprintf(stderr, "%s\n", s.ToString().c_str());
       return;

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -71,7 +71,7 @@ class SpecialEnv : public EnvWrapper {
     count_random_reads_ = false;
   }
 
-  Status NewWritableFile(const std::string& f, WritableFile** r) {
+  Status NewWritableFile(const std::string& f, WritableFile** r, size_t map_size) {
     class SSTableFile : public WritableFile {
      private:
       SpecialEnv* env_;
@@ -105,7 +105,7 @@ class SpecialEnv : public EnvWrapper {
       return Status::IOError("simulated write error");
     }
 
-    Status s = target()->NewWritableFile(f, r);
+    Status s = target()->NewWritableFile(f, r, 2<<20);
     if (s.ok()) {
       if (strstr(f.c_str(), ".sst") != NULL) {
         *r = new SSTableFile(this, *r);

--- a/db/repair.cc
+++ b/db/repair.cc
@@ -408,7 +408,7 @@ class Repairer {
   Status WriteDescriptor() {
     std::string tmp = TempFileName(dbname_, 1);
     WritableFile* file;
-    Status status = env_->NewWritableFile(tmp, &file);
+    Status status = env_->NewWritableFile(tmp, &file, 4096);
     if (!status.ok()) {
       return status;
     }

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -884,7 +884,7 @@ Status VersionSet::LogAndApply(VersionEdit* edit, port::Mutex* mu) {
     assert(descriptor_file_ == NULL);
     new_manifest_file = DescriptorFileName(dbname_, manifest_file_number_);
     edit->SetNextFile(next_file_number_);
-    s = env_->NewWritableFile(new_manifest_file, &descriptor_file_);
+    s = env_->NewWritableFile(new_manifest_file, &descriptor_file_, 4*1024L);
     if (s.ok()) {
       descriptor_log_ = new log::Writer(descriptor_file_);
       s = WriteSnapshot(descriptor_log_);
@@ -1853,7 +1853,7 @@ bool Compaction::ShouldStopBefore(const Slice& internal_key, size_t key_count) {
     //  to meet file open speed goals
     else
     {
-      ret_flag=(75000<key_count);
+      ret_flag=(300000<key_count);
      } // else
   }  // if
 

--- a/helpers/memenv/memenv.cc
+++ b/helpers/memenv/memenv.cc
@@ -257,7 +257,7 @@ class InMemoryEnv : public EnvWrapper {
   }
 
   virtual Status NewWritableFile(const std::string& fname,
-                                 WritableFile** result) {
+                                 WritableFile** result, size_t) {
     MutexLock lock(&mutex_);
     if (file_map_.find(fname) != file_map_.end()) {
       DeleteFileInternal(fname);

--- a/helpers/memenv/memenv_test.cc
+++ b/helpers/memenv/memenv_test.cc
@@ -41,7 +41,7 @@ TEST(MemEnvTest, Basics) {
   ASSERT_EQ(0, children.size());
 
   // Create a file.
-  ASSERT_OK(env_->NewWritableFile(dbname + "/f", &writable_file));
+  ASSERT_OK(env_->NewWritableFile(dbname + "/f", &writable_file, 2<<20));
   delete writable_file;
 
   // Check that the file exists.
@@ -53,7 +53,7 @@ TEST(MemEnvTest, Basics) {
   ASSERT_EQ("f", children[0]);
 
   // Write to the file.
-  ASSERT_OK(env_->NewWritableFile(dbname + "/f", &writable_file));
+  ASSERT_OK(env_->NewWritableFile(dbname + "/f", &writable_file, 2<<20));
   ASSERT_OK(writable_file->Append("abc"));
   delete writable_file;
 
@@ -98,7 +98,7 @@ TEST(MemEnvTest, ReadWrite) {
 
   ASSERT_OK(env_->CreateDir(dbname + ""));
 
-  ASSERT_OK(env_->NewWritableFile(dbname + "/f", &writable_file));
+  ASSERT_OK(env_->NewWritableFile(dbname + "/f", &writable_file, 2<<20));
   ASSERT_OK(writable_file->Append("hello "));
   ASSERT_OK(writable_file->Append("world"));
   delete writable_file;
@@ -145,7 +145,7 @@ TEST(MemEnvTest, Misc) {
   ASSERT_TRUE(!test_dir.empty());
 
   WritableFile* writable_file;
-  ASSERT_OK(env_->NewWritableFile("/a/b", &writable_file));
+  ASSERT_OK(env_->NewWritableFile("/a/b", &writable_file, 2<<20));
 
   // These are no-ops, but we test they return success.
   ASSERT_OK(writable_file->Sync());
@@ -167,7 +167,7 @@ TEST(MemEnvTest, LargeWrite) {
   }
 
   WritableFile* writable_file;
-  ASSERT_OK(env_->NewWritableFile(dbname + "/f", &writable_file));
+  ASSERT_OK(env_->NewWritableFile(dbname + "/f", &writable_file, 2<<20));
   ASSERT_OK(writable_file->Append("foo"));
   ASSERT_OK(writable_file->Append(write_data));
   delete writable_file;

--- a/include/leveldb/env.h
+++ b/include/leveldb/env.h
@@ -22,13 +22,14 @@
 
 namespace leveldb {
 
+class AppendableFile;
 class FileLock;
+class Options;
 class Logger;
 class RandomAccessFile;
 class SequentialFile;
 class Slice;
 class WritableFile;
-class AppendableFile;
 
 class Env {
  public:
@@ -181,6 +182,10 @@ class Env {
 
   // Riak specific:  Get object that is tracking various software counters
   virtual PerformanceCounters * GetPerformanceCounters() {return(gPerfCounters);};
+
+  // Riak specific:  Request size of recovery memory map, potentially using
+  //  Options data for the decision.  Default 2Mbyte is Google's original size.
+  virtual size_t RecoveryMmapSize(const struct Options *) const {return(2*1024*1024L);};
 
  private:
   // No copying allowed

--- a/include/leveldb/env.h
+++ b/include/leveldb/env.h
@@ -74,7 +74,8 @@ class Env {
   //
   // The returned file will only be accessed by one thread at a time.
   virtual Status NewWritableFile(const std::string& fname,
-                                 WritableFile** result) = 0;
+                                 WritableFile** result,
+                                 size_t map_size) = 0;
 
   // Riak specific:
   // Derived from NewWritableFile.  One change: if the file exists,
@@ -85,7 +86,8 @@ class Env {
   //
   // The returned file will only be accessed by one thread at a time.
   virtual Status NewAppendableFile(const std::string& fname,
-                                   WritableFile** result) = 0;
+                                   WritableFile** result,
+                                   size_t map_size) = 0;
 
   // Riak specific:
   // Allows for virtualized version of NewWritableFile that enables write
@@ -94,8 +96,9 @@ class Env {
   //
   // The returned file will only be accessed by one thread at a time.
   virtual Status NewWriteOnlyFile(const std::string& fname,
-                                   WritableFile** result)
-  {return(NewWritableFile(fname, result));};
+                                  WritableFile** result,
+                                  size_t map_size)
+  {return(NewWritableFile(fname, result, map_size));};
 
   // Returns true iff the named file exists.
   virtual bool FileExists(const std::string& fname) = 0;
@@ -333,14 +336,14 @@ class EnvWrapper : public Env {
   Status NewRandomAccessFile(const std::string& f, RandomAccessFile** r) {
     return target_->NewRandomAccessFile(f, r);
   }
-  Status NewWritableFile(const std::string& f, WritableFile** r) {
-    return target_->NewWritableFile(f, r);
+  Status NewWritableFile(const std::string& f, WritableFile** r, size_t s=0) {
+    return target_->NewWritableFile(f, r, s);
   }
-  Status NewAppendableFile(const std::string& f, WritableFile** r) {
-    return target_->NewAppendableFile(f, r);
+  Status NewAppendableFile(const std::string& f, WritableFile** r, size_t s=0) {
+      return target_->NewAppendableFile(f, r, s);
   }
-  Status NewWriteOnlyFile(const std::string& f, WritableFile** r) {
-    return target_->NewWriteOnlyFile(f, r);
+  Status NewWriteOnlyFile(const std::string& f, WritableFile** r, size_t s=0) {
+    return target_->NewWriteOnlyFile(f, r, s);
   }
   bool FileExists(const std::string& f) { return target_->FileExists(f); }
   Status GetChildren(const std::string& dir, std::vector<std::string>* r) {

--- a/include/leveldb/options.h
+++ b/include/leveldb/options.h
@@ -183,6 +183,9 @@ struct Options {
   // Default: false
   bool limited_developer_mem;
 
+  // The size of each MMAped file, choose 0 for the default (20M)
+  uint64_t mmap_size;
+
   // Riak option to adjust aggressive delete behavior.
   //  - zero disables aggressive delete
   //  - positive value indicates how many deletes must exist

--- a/table/format.cc
+++ b/table/format.cc
@@ -190,7 +190,7 @@ Status ReadBlock(RandomAccessFile* file,
 
               // create / append file to hold removed blocks
               new_name+="/BLOCKS.bad";
-              s2=options.GetEnv()->NewAppendableFile(new_name, &bad_file);
+              s2=options.GetEnv()->NewAppendableFile(new_name, &bad_file, 4*1024);
               if (s2.ok())
               {
                   // need a try/catch

--- a/util/cache2.cc
+++ b/util/cache2.cc
@@ -439,16 +439,9 @@ DoubleCache::DoubleCache(
     // fixed allocation for recovery log and info LOG: 20M each
     //  (with 64 or open databases, this is a serious number)
     // and fixed allocation for two write buffers
-    size_t map_size;
 
-    // large buffers, try for a little bit bigger than half hoping
-    //  for two writes ... not three
-    if (10*1024*1024 < options.write_buffer_size)
-        map_size=(options.write_buffer_size/6)*4;
-    else
-        map_size=(options.write_buffer_size*12)/10;  // integer multiply 1.2
-
-    m_Overhead=options.write_buffer_size*2 + map_size + 4096;
+    m_Overhead=options.write_buffer_size*2 
+        + options.env->RecoveryMmapSize(&options) + 4096;
     m_TotalAllocation=gFlexCache.GetDBCacheCapacity(m_IsInternalDB);
 
     if (m_Overhead < m_TotalAllocation)

--- a/util/env.cc
+++ b/util/env.cc
@@ -37,7 +37,7 @@ static Status DoWriteStringToFile(Env* env, const Slice& data,
                                   const std::string& fname,
                                   bool should_sync) {
   WritableFile* file;
-  Status s = env->NewWritableFile(fname, &file);
+  Status s = env->NewWritableFile(fname, &file, 4*1024L);
   if (!s.ok()) {
     return s;
   }

--- a/util/env_posix.cc
+++ b/util/env_posix.cc
@@ -779,6 +779,25 @@ class PosixEnv : public Env {
     {return(gImmThreads->m_WorkQueueAtomic + gWriteThreads->m_WorkQueueAtomic
           + gLevel0Threads->m_WorkQueueAtomic + gCompactionThreads->m_WorkQueueAtomic);};
 
+  virtual size_t RecoveryMmapSize(const struct Options * options) const
+    {
+      size_t map_size;
+
+      if (NULL!=options)
+      {
+        // large buffers, try for a little bit bigger than half hoping
+        //  for two writes ... not three
+        if (10*1024*1024 < options->write_buffer_size)
+            map_size=(options->write_buffer_size/6)*4;
+        else
+            map_size=(options->write_buffer_size*12)/10;  // integer multiply 1.2
+      } // if
+      else
+        map_size=2*1024*1024L;
+
+      return(map_size);
+    };
+
  private:
 
   void PthreadCall(const char* label, int result) {

--- a/util/flexcache_test.cc
+++ b/util/flexcache_test.cc
@@ -44,8 +44,8 @@ TEST(FlexCacheTest, UserSizing) {
 
     options.create_if_missing=true;
     options.filter_policy=NewBloomFilterPolicy2(16);
-    options.total_leveldb_mem=300*1024*1024L;
-    options.write_buffer_size=4*1024*1024L;
+    options.total_leveldb_mem=1000*1024*1024L;
+    options.write_buffer_size=45*1024*1024L;
 
     // verify accounting with one database
     dbname = test::TmpDir() + "/flexcache0";
@@ -54,10 +54,10 @@ TEST(FlexCacheTest, UserSizing) {
     ASSERT_EQ(1, DBList()->GetDBCount(false));
 
     db[0]->GetProperty("leveldb.block-cache", &value);
-    ASSERT_EQ(252*1024*1024l, atoi(value.c_str()));
+    ASSERT_EQ(922742784L, atoi(value.c_str()));
 
     db[0]->GetProperty("leveldb.file-cache", &value);
-    ASSERT_EQ(250*1024*1024L, atoi(value.c_str()));
+    ASSERT_EQ(920645632L, atoi(value.c_str()));
 
     // verify accounting with three databases
     dbname = test::TmpDir() + "/flexcache1";
@@ -69,32 +69,32 @@ TEST(FlexCacheTest, UserSizing) {
     ASSERT_EQ(3, DBList()->GetDBCount(false));
 
     db[0]->GetProperty("leveldb.block-cache", &value);
-    ASSERT_EQ(52*1024*1024l, atoi(value.c_str()));
+    ASSERT_EQ(223692117L, atoi(value.c_str()));
 
     db[0]->GetProperty("leveldb.file-cache", &value);
-    ASSERT_EQ(50*1024*1024L, atoi(value.c_str()));
+    ASSERT_EQ(221594965L, atoi(value.c_str()));
 
     db[1]->GetProperty("leveldb.block-cache", &value);
-    ASSERT_EQ(52*1024*1024l, atoi(value.c_str()));
+    ASSERT_EQ(223692117L, atoi(value.c_str()));
 
     db[1]->GetProperty("leveldb.file-cache", &value);
-    ASSERT_EQ(50*1024*1024L, atoi(value.c_str()));
+    ASSERT_EQ(221594965L, atoi(value.c_str()));
 
     db[2]->GetProperty("leveldb.block-cache", &value);
-    ASSERT_EQ(52*1024*1024l, atoi(value.c_str()));
+    ASSERT_EQ(223692117L, atoi(value.c_str()));
 
     db[2]->GetProperty("leveldb.file-cache", &value);
-    ASSERT_EQ(50*1024*1024L, atoi(value.c_str()));
+    ASSERT_EQ(221594965L, atoi(value.c_str()));
 
     // verify accounting after two databases go away
     delete db[0];
     delete db[2];
 
     db[1]->GetProperty("leveldb.block-cache", &value);
-    ASSERT_EQ(252*1024*1024l, atoi(value.c_str()));
+    ASSERT_EQ(922742784L, atoi(value.c_str()));
 
     db[1]->GetProperty("leveldb.file-cache", &value);
-    ASSERT_EQ(250*1024*1024L, atoi(value.c_str()));
+    ASSERT_EQ(920645632L, atoi(value.c_str()));
 
     // rebuild from zero to ten databases, verify accounting
     delete db[1];
@@ -112,10 +112,10 @@ TEST(FlexCacheTest, UserSizing) {
     for(loop=0; loop<10; ++loop)
     {
         db[loop]->GetProperty("leveldb.block-cache", &value);
-        ASSERT_EQ(252*1024*1024l, atoi(value.c_str()));
+        ASSERT_EQ(188739584l, atoi(value.c_str()));
 
         db[loop]->GetProperty("leveldb.file-cache", &value);
-        ASSERT_EQ(250*1024*1024L, atoi(value.c_str()));
+        ASSERT_EQ(186642432L, atoi(value.c_str()));
     }   // for
 
     for (loop=0; loop<10; ++loop)
@@ -141,8 +141,8 @@ TEST(FlexCacheTest, MixedSizing) {
 
     options.create_if_missing=true;
     options.filter_policy=NewBloomFilterPolicy2(16);
-    options.total_leveldb_mem=300*1024*1024L;
-    options.write_buffer_size=4*1024*1024L;
+    options.total_leveldb_mem=1000*1024*1024L;
+    options.write_buffer_size=45*1024*1024L;
 
     // verify accounting with one user & one internal
     dbname = test::TmpDir() + "/flexcache0";
@@ -152,46 +152,46 @@ TEST(FlexCacheTest, MixedSizing) {
     ASSERT_EQ(0, DBList()->GetDBCount(true));
 
     db[0]->GetProperty("leveldb.block-cache", &value);
-    ASSERT_EQ(252*1024*1024l, atoi(value.c_str()));
+    ASSERT_EQ(922742784l, atoi(value.c_str()));
 
     db[0]->GetProperty("leveldb.file-cache", &value);
-    ASSERT_EQ(250*1024*1024L, atoi(value.c_str()));
+    ASSERT_EQ(920645632L, atoi(value.c_str()));
 
-    // raise memory and add internal
+    // add internal
     dbname = test::TmpDir() + "/flexcache1";
     options.is_internal_db=true;
-    options.total_leveldb_mem=600*1024*1024L;
+    options.total_leveldb_mem=1600*1024*1024L;
     st=DB::Open(options, dbname, &db[1]);
     ASSERT_OK(st);
     ASSERT_EQ(1, DBList()->GetDBCount(false));
     ASSERT_EQ(1, DBList()->GetDBCount(true));
 
     db[0]->GetProperty("leveldb.block-cache", &value);
-    ASSERT_EQ(432*1024*1024l, atoi(value.c_str()));
+    ASSERT_EQ(1216344064l, atoi(value.c_str()));
 
     db[0]->GetProperty("leveldb.file-cache", &value);
-    ASSERT_EQ(430*1024*1024L, atoi(value.c_str()));
+    ASSERT_EQ(1214246912L, atoi(value.c_str()));
 
     db[1]->GetProperty("leveldb.block-cache", &value);
-    ASSERT_EQ(72*1024*1024l, atoi(value.c_str()));
+    ASSERT_EQ(209711104l, atoi(value.c_str()));
 
     db[1]->GetProperty("leveldb.file-cache", &value);
-    ASSERT_EQ(70*1024*1024L, atoi(value.c_str()));
+    ASSERT_EQ(207613952L, atoi(value.c_str()));
 
     delete db[0];
     ASSERT_EQ(0, DBList()->GetDBCount(false));
     ASSERT_EQ(1, DBList()->GetDBCount(true));
     db[1]->GetProperty("leveldb.block-cache", &value);
-    ASSERT_EQ(72*1024*1024L, atoi(value.c_str()));
+    ASSERT_EQ(209711104L, atoi(value.c_str()));
 
     db[1]->GetProperty("leveldb.file-cache", &value);
-    ASSERT_EQ(70*1024*1024L, atoi(value.c_str()));
+    ASSERT_EQ(207613952L, atoi(value.c_str()));
 
     delete db[1];
 
 
     // rebuild from zero to ten databases, verify accounting
-    options.total_leveldb_mem=3000*1024*1024L;
+    options.total_leveldb_mem=4000*1024*1024L;
 
     for(loop=0; loop<10; ++loop)
     {
@@ -210,18 +210,18 @@ TEST(FlexCacheTest, MixedSizing) {
         if (0==(loop %2))
         {
             db[loop]->GetProperty("leveldb.block-cache", &value);
-            ASSERT_EQ(432*1024*1024l, atoi(value.c_str()));
+            ASSERT_EQ(545255424l, atoi(value.c_str()));
 
             db[loop]->GetProperty("leveldb.file-cache", &value);
-            ASSERT_EQ(430*1024*1024L, atoi(value.c_str()));
+            ASSERT_EQ(543158272L, atoi(value.c_str()));
         }   // if
         else
         {
             db[loop]->GetProperty("leveldb.block-cache", &value);
-            ASSERT_EQ(72*1024*1024l, atoi(value.c_str()));
+            ASSERT_EQ(41938944l, atoi(value.c_str()));
 
             db[loop]->GetProperty("leveldb.file-cache", &value);
-            ASSERT_EQ(70*1024*1024L, atoi(value.c_str()));
+            ASSERT_EQ(39841792L, atoi(value.c_str()));
         }   // else
     }   // for
 

--- a/util/options.cc
+++ b/util/options.cc
@@ -37,6 +37,7 @@ Options::Options()
       total_leveldb_mem(0),
       block_cache_threshold(32<<20),
       limited_developer_mem(false),
+      mmap_size(0),
       delete_threshold(1000),
       fadvise_willneed(false),
       tiered_slow_level(0)
@@ -68,6 +69,7 @@ Options::Dump(
     Log(log,"     Options.total_leveldb_mem: %" PRIu64, total_leveldb_mem);
     Log(log," Options.block_cache_threshold: %" PRIu64, block_cache_threshold);
     Log(log," Options.limited_developer_mem: %s", limited_developer_mem ? "true" : "false");
+    Log(log,"             Options.mmap_size: %" PRIu64, mmap_size);
     Log(log,"      Options.delete_threshold: %" PRIu64, delete_threshold);
     Log(log,"      Options.fadvise_willneed: %s", fadvise_willneed ? "true" : "false");
     Log(log,"     Options.tiered_slow_level: %d", tiered_slow_level);

--- a/util/testutil.h
+++ b/util/testutil.h
@@ -37,13 +37,13 @@ class ErrorEnv : public EnvWrapper {
                num_writable_file_errors_(0) { }
 
   virtual Status NewWritableFile(const std::string& fname,
-                                 WritableFile** result) {
+                                 WritableFile** result, size_t map_size) {
     if (writable_file_error_) {
       ++num_writable_file_errors_;
       *result = NULL;
       return Status::IOError(fname, "fake error");
     }
-    return target()->NewWritableFile(fname, result);
+    return target()->NewWritableFile(fname, result, map_size);
   }
 };
 


### PR DESCRIPTION
All types of memory mapped files previously shared the same mapping size of 20Mbytes.  This is wasteful for many files, especially the smaller files created by Riak's AAE feature.  The waste is in two forms.  First the full 20Mbytes is always reserved by leveldb's flexcache.  This could lead to 2.5Gbytes of available memory being set aside unnecessarily for a node with 64 databases/vnodes/partitions.  The second waste is in physical writes to disk.  The entire 20Mbyte mapping is written to disk, then the file is resized smaller.  Again, this is a heavy burden for small files.
