### PR TITLE
Give Read and Iterator calls more consistent disk access on moderately loaded systems.

### DIFF
--- a/db/corruption_test.cc
+++ b/db/corruption_test.cc
@@ -328,8 +328,10 @@ TEST(CorruptionTest, CompactionInputErrorParanoid) {
   // Fill levels >= 1 so memtable compaction outputs to level 1
   //  matthewv 1/10/14 - what does "levels" have to do with this,
   //  switching to compaction trigger.
+  // 7/10/14 - compaction starts between 4 and 6 files ... assume 4
+  //  (will make a new, descriptive constant for 4)
   for (int level = Property("leveldb.num-files-at-level0")+1;
-       level < (config::kL0_CompactionTrigger -1); level++) {
+       level < (config::kL0_GroomingTrigger -1); level++) {
     dbi->Put(WriteOptions(), "", "begin");
     dbi->Put(WriteOptions(), "~", "end");
     dbi->TEST_CompactMemTable();

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -1187,8 +1187,8 @@ DBImpl::Send2PageCache(
 
     // tune fadvise to keep all of the lower level file in page cache
     //  (compaction of unsorted files causes severe cache misses)
-//    if (versions_->IsLevelOverlapped(compact->compaction->level()))
-    if (0==compact->compaction->level())
+    if (versions_->IsLevelOverlapped(compact->compaction->level()))
+//    if (0==compact->compaction->level())
     {
         ret_flag=true;
     }   // if

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -1005,11 +1005,13 @@ TEST(DBTest, SparseMerge) {
 
   // Compactions should not cause us to create a situation where
   // a file overlaps too much data at the next level.
-  ASSERT_LE(dbfull()->TEST_MaxNextLevelOverlappingBytes(), 20*1048576);
+  // 07/10/14 matthewv - we overlap first two levels.  sparse test not appropriate there,
+  //                     and we set overlaps into 100s of megabytes as "normal"
+//  ASSERT_LE(dbfull()->TEST_MaxNextLevelOverlappingBytes(), 20*1048576);
   dbfull()->TEST_CompactRange(0, NULL, NULL);
-  ASSERT_LE(dbfull()->TEST_MaxNextLevelOverlappingBytes(), 20*1048576);
+//  ASSERT_LE(dbfull()->TEST_MaxNextLevelOverlappingBytes(), 20*1048576);
   dbfull()->TEST_CompactRange(1, NULL, NULL);
-  ASSERT_LE(dbfull()->TEST_MaxNextLevelOverlappingBytes(), 20*1048576);
+//  ASSERT_LE(dbfull()->TEST_MaxNextLevelOverlappingBytes(), 20*1048576);
 }
 
 static bool Between(uint64_t val, uint64_t low, uint64_t high) {

--- a/db/dbformat.h
+++ b/db/dbformat.h
@@ -28,6 +28,10 @@ static const int kNumOverlapLevels = 2;
 // Google:  static const size_t kL0_CompactionTrigger = 4;
 static const size_t kL0_CompactionTrigger = 6;
 
+// Level-0 (any overlapped level) number of files where a grooming
+//     compaction could start
+static const size_t kL0_GroomingTrigger = 4;
+
 // Soft limit on number of level-0 files.  We slow down writes at this point.
 static const size_t kL0_SlowdownWritesTrigger = 8;
 

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1139,6 +1139,14 @@ VersionSet::Finalize(Version* v)
                 }   // if
 
                 is_grooming=false;
+
+                // early overlapped compaction
+                //  only occurs if no other compactions running on groomer thread
+                if (0==score && 4<=v->files_[level].size())
+                {
+                    score=1;
+                    is_grooming=true;
+                }   // if
             } else {
                 // Compute the ratio of current size to size limit.
                 const uint64_t level_bytes = TotalFileSize(v->files_[level]);

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1142,7 +1142,7 @@ VersionSet::Finalize(Version* v)
 
                 // early overlapped compaction
                 //  only occurs if no other compactions running on groomer thread
-                if (0==score && 4<=v->files_[level].size())
+                if (0==score && config::kL0_GroomingTrigger<=v->files_[level].size())
                 {
                     score=1;
                     is_grooming=true;

--- a/util/hot_threads.h
+++ b/util/hot_threads.h
@@ -138,7 +138,7 @@ public:
 
     static void *ThreadStart(void *args);
 
-    bool FindWaitingThread(ThreadTask * work);
+    bool FindWaitingThread(ThreadTask * work, bool OkToQueue=true);
 
     bool Submit(ThreadTask * item, bool OkToQueue=true);
 


### PR DESCRIPTION
Basho's leveldb tunings have emphasized write performance.  There are now times when the background compactions can consume the disk subsystem's capacity.  This leads to delayed Read and Iterator (2i) operations.  This branch spreads out background compactions on moderately loaded systems without sacrificing the total write throughput available for heavily load situations.

Discussion here:
https://github.com/basho/leveldb/wiki/mv-pacing
