### PR TITLE
Mv sequential tuning #146 [JIRA: RIAK-1477]

### DIFF
--- a/README
+++ b/README
@@ -3,6 +3,8 @@ Authors: Sanjay Ghemawat (sanjay@google.com) and Jeff Dean (jeff@google.com)
 
 The original Google README is now README.GOOGLE.
 
+** Introduction
+
 This repository contains the Google source code as modified to benefit
 the Riak environment.  The typical Riak environment has two attributes
 that necessitate leveldb adjustments, both in options and code:
@@ -13,13 +15,19 @@ that necessitate leveldb adjustments, both in options and code:
   hardware CRC calculation, increasing Bloom filter accuracy, and
   defaulting to integrity checking enabled.
 
-- multiple databases open: Riak opens 8 to 64 databases
+- multiple databases open: Riak opens 8 to 128 databases
   simultaneously.  Google's leveldb supports this, but its background
   compaction thread can fall behind.  leveldb will "stall" new user
   writes whenever the compaction thread gets too far behind.  Basho's
   leveldb modification include multiple thread blocks that each
   contain prioritized threads for specific compaction activities.
 
+Details for Basho's customizations exist in the leveldb wiki:
+
+  http://github.com/basho/leveldb/wiki
+
+
+** Branch pattern
 
 This repository follows the Basho standard for branch management 
 as of November 28, 2013.  The standard is found here:
@@ -31,6 +39,8 @@ engineering work.  The "master" branch contains the most recently
 released work, i.e. distributed as part of a Riak release.
 
 
+** Basic options needed
+
 Those wishing to truly savor the benefits of Basho's modifications
 need to initialize a new leveldb::Options structure similar to the
 following before each call to leveldb::DB::Open:
@@ -40,47 +50,35 @@ following before each call to leveldb::DB::Open:
     options=new Leveldb::Options;
 
     options.filter_policy=leveldb::NewBloomFilterPolicy2(16);
-    options.block_cache=leveldb::NewLRUCache(536870912);
-    options.max_open_files=500;
-    options.write_buffer_size=62914560;
+    options.write_buffer_size=62914560;  // 60Mbytes
+    options.total_leveldb_mem=2684354560; // 2.5Gbytes (details below)
     options.env=leveldb::Env::Default();
 
 
-Memory usage by leveldb is largely controlled by three
-leveldb::Options variables: write_buffer_size, max_open_files, and
-size used to initial block_cache.
+** Memory plan
 
-- write_buffer_size: Riak randomizes the write_buffer_size across its
-  multiple databases between 30Mbytes and 60Mbytes.  Internal, leveldb
-  could have two of these active for an open database.  Google's
-  default is 4Mbyte.  Basho's leveldb has been tuned to the 30Mbyte to
-  60Mbyte range, but does not block larger values (though larger
-  values are just untested).
+Basho's leveldb dramatically departed from Google's original internal
+memory allotment plan with Riak 2.0.  Basho's leveldb uses a methodology
+called flexcache.  The technical details are here:
 
-- max_open_files: Riak 1.4 simplified calculating the memory impact of
-  max_open_files.  Basho's leveldb now simply multiplies
-  max_open_files by 4Mbytes to establish the file cache limit.  The
-  file cache is therefore really a limit on many files' metadata can
-  fit.  max_open_files was originally a file handle limit, but file
-  metadata is now a much larger resource concern.  The impact of
-  Basho's larger table files and Google's recent addition of Bloom
-  filters made the accounting switch necessary.  Where server
-  resources allow, the value of max_open_files should exceed the count
-  of .sst table files within the database directory.  Memory budgeting
-  for this variable is more important to random read operations than
-  the block_cache.
+   https://github.com/basho/leveldb/wiki/mv-flexcache
 
-- block_cache: The block cache holds data blocks that leveldb has
-  recently retrieved from .sst table files.  Any given block contains
-  one or more complete key/value pairs.  The cache speeds up repeat
-  access to the same key and potential access to adjacent keys.  Basho
-  has tested this as high as 2Gbytes.  (Note: the older leveldb
-  released in Riak 1.2 had a bug that hurt performance with values
-  above 8Mbytes … that was fixed in the Riak 1.3 release)
+The key points are:
 
-So estimated memory usage of a database =
+- options.total_leveldb_mem is an allocation for the entire process,
+  not a single database
 
-    write_buffer_size*2 
-  + max_open_files*4194304 
-  + (size in NewLRUCache initialization)
+- giving different values to options.total_leveldb_mem on subsequent Open
+  calls causes memory to rearrange to current value across all databases
+
+- leveldb can readily execute with 100Mbytes or less, but at least 340Mbytes 
+  per database is helpful.  
+
+- there is a performance sweet spot at 2.5Gbytes per database (3.0Gbytes
+  if using Riak's active anti-entropy).  Even more is nice, but not as helpful.
+
+- never assign more than 75% of available RAM to total_leveldb_mem.  There is
+  too much unaccounted memory overhead (worse if you use tcmalloc library).
+
+- options.max_open_files and options.block_cache should not be used.
   

--- a/README
+++ b/README
@@ -71,10 +71,9 @@ The key points are:
 - giving different values to options.total_leveldb_mem on subsequent Open
   calls causes memory to rearrange to current value across all databases
 
-- leveldb can readily execute with 100Mbytes or less, but at least 340Mbytes 
-  per database is helpful.  
+- recommended minimum for Basho's leveldb is 340Mbytes per database.  
 
-- there is a performance sweet spot at 2.5Gbytes per database (3.0Gbytes
+- performance improves rapidly from 340Mbytes to 2.5Gbytes per database (3.0Gbytes
   if using Riak's active anti-entropy).  Even more is nice, but not as helpful.
 
 - never assign more than 75% of available RAM to total_leveldb_mem.  There is

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -1178,6 +1178,17 @@ Status DBImpl::OpenCompactionOutputFile(
 
       }   // if
 
+      // force call to CalcInputState to set IsCompressible
+      compact->compaction->CalcInputStats(*table_cache_);
+
+      // do not attempt compression if data known to not compress
+      if (kSnappyCompression==options.compression && !compact->compaction->IsCompressible())
+      {
+          options.compression=kNoCompressionAutomated;
+          Log(options.info_log, "kNoCompressionAutomated");
+      }   // if
+
+
       // tune fadvise to keep as much of the file data in RAM as
       //  reasonably possible
       if (pagecache_flag)

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -1035,6 +1035,7 @@ Status DBImpl::BackgroundCompaction(
         c->edit()->AddFile(c->level() + 1, f->number, f->file_size,
                            f->smallest, f->largest);
         status = versions_->LogAndApply(c->edit(), &mutex_);
+        DeleteObsoleteFiles();
 
         // if LogAndApply fails, should file be renamed back to original spot?
         VersionSet::LevelSummaryStorage tmp;

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -130,15 +130,18 @@ Options SanitizeOptions(const std::string& dbname,
   ClipToRange(&result.write_buffer_size,         64<<10, 1<<30);
   ClipToRange(&result.block_size,                1<<10,  4<<20);
 
-  if (src.limited_developer_mem)
-      gMapSize=2*1024*1024L;
-
   // alternate means to change gMapSize ... more generic
   if (0!=src.mmap_size)
       gMapSize=src.mmap_size;
 
-  if (gMapSize < result.write_buffer_size) // let unit tests be smaller
-      result.write_buffer_size=gMapSize;
+  // reduce buffer sizes if limited_developer_mem is true
+  if (src.limited_developer_mem)
+  {
+      if (0==src.mmap_size)
+          gMapSize=2*1024*1024L;
+      if (gMapSize < result.write_buffer_size) // let unit tests be smaller
+          result.write_buffer_size=gMapSize;
+  }   // if
 
   // Validate tiered storage options
   tiered_dbname=MakeTieredDbname(dbname, result);

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -1428,12 +1428,15 @@ TEST(DBTest, ManualCompaction) {
   ASSERT_EQ("3", FilesPerLevel());
 
   // Compaction range falls before files
+  // (Basho compacts all at zero no matter what)
   Compact("", "c");
-  ASSERT_EQ("3", FilesPerLevel());
+  //ASSERT_EQ("3", FilesPerLevel());
+  ASSERT_EQ("0,1", FilesPerLevel());
 
   // Compaction range falls after files
   Compact("r", "z");
-  ASSERT_EQ("3", FilesPerLevel());
+  //ASSERT_EQ("3", FilesPerLevel());
+  ASSERT_EQ("0,1", FilesPerLevel());
 
   // Compaction range overlaps files
   Compact("p1", "p9");

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1782,7 +1782,7 @@ bool Compaction::IsTrivialMove() const {
   return (!gLevelTraits[level_].m_OverlappedFiles &&
           num_input_files(0) == 1 &&
           num_input_files(1) == 0 &&
-          TotalFileSize(grandparents_) <= gLevelTraits[level_].m_MaxGrandParentOverlapBytes);
+          (uint64_t)TotalFileSize(grandparents_) <= gLevelTraits[level_].m_MaxGrandParentOverlapBytes);
 #else
   // removed this functionality when creating gLevelTraits[].m_OverlappedFiles
   //  flag.  "Move" was intented by Google to delay compaction by moving small

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -239,11 +239,16 @@ class VersionSet {
       penalty=current_->write_penalty_;
       throttle=GetThrottleWriteRate();
 
+
       ret_val=0;
       if (0==penalty && 1!=throttle)
           ret_val=(int)throttle;
       else if (0!=penalty)
+      {
+          if (1==throttle)
+              throttle=GetUnadjustedThrottleWriteRate();
           ret_val=(int)penalty * throttle;
+      }   // else if
 
       return(ret_val);
   }

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -433,6 +433,7 @@ class Compaction {
   size_t AverageValueSize()  const {return(avg_value_size_);};
   size_t AverageKeySize()    const {return(avg_key_size_);};
   size_t AverageBlockSize()  const {return(avg_block_size_);};
+  bool IsCompressible()      const {return(compressible_);};
 
  private:
   friend class Version;
@@ -470,6 +471,7 @@ class Compaction {
   size_t avg_value_size_;
   size_t avg_key_size_;
   size_t avg_block_size_;
+  bool compressible_;
   bool stats_done_;
 };
 

--- a/include/leveldb/options.h
+++ b/include/leveldb/options.h
@@ -30,7 +30,8 @@ enum CompressionType {
   // NOTE: do not change the values of existing entries, as these are
   // part of the persistent format on disk.
   kNoCompression     = 0x0,
-  kSnappyCompression = 0x1
+  kSnappyCompression = 0x1,
+  kNoCompressionAutomated = 0x3
 };
 
 // Options to control the behavior of a database (passed to DB::Open)

--- a/include/leveldb/perf_count.h
+++ b/include/leveldb/perf_count.h
@@ -225,6 +225,11 @@ enum PerformanceCountersEnum
 
     ePerfApiDelete=89,        //!< Count of DB::Delete
 
+    ePerfBGMove=90,           //!< compaction was a successful move
+    ePerfBGMoveFail=91,       //!< compaction move failed, regular compaction attempted
+
+    ePerfThrottleUnadjusted=92,//!< current unadjusted throttle gauge
+
     // must follow last index name to represent size of array
     //  (ASSUMES previous enum is highest value)
     ePerfCountEnumSize,     //!< size of the array described by the enum values

--- a/table/table_builder.cc
+++ b/table/table_builder.cc
@@ -175,6 +175,13 @@ void TableBuilder::WriteBlock(BlockBuilder* block, BlockHandle* handle) {
   CompressionType type = r->options.compression;
   // TODO(postrelease): Support more compression options: zlib?
   switch (type) {
+    case kNoCompressionAutomated:
+      // automation disabled compression
+      type=kNoCompression;
+      r->sst_counters.Inc(eSstCountCompressAborted);
+      block_contents = raw;
+      break;
+
     case kNoCompression:
       block_contents = raw;
       break;

--- a/util/options.cc
+++ b/util/options.cc
@@ -34,7 +34,7 @@ Options::Options()
       filter_policy(NULL),
       is_repair(false),
       is_internal_db(false),
-      total_leveldb_mem(0),
+      total_leveldb_mem(2684354560ll),
       block_cache_threshold(32<<20),
       limited_developer_mem(false),
       mmap_size(0),

--- a/util/perf_count.cc
+++ b/util/perf_count.cc
@@ -616,7 +616,10 @@ PerformanceCounters * gPerfCounters(&LocalStartupCounters);
         "FileCacheRemove",
         "BlockCacheInsert",
         "BlockCacheRemove",
-        "ApiDelete"
+        "ApiDelete",
+        "BGMove",
+        "BGMoveFail",
+        "ThrottleUnadjusted"
     };
 
 

--- a/util/throttle.cc
+++ b/util/throttle.cc
@@ -94,6 +94,7 @@ ThrottleThread(
     gThrottleRunning=true;
     now_seconds=0;
     cache_expire=0;
+    new_unadjusted=1;
 
     while(gThrottleRunning)
     {

--- a/util/throttle.cc
+++ b/util/throttle.cc
@@ -54,7 +54,7 @@ struct ThrottleData_t
 
 ThrottleData_t gThrottleData[THROTTLE_INTERVALS];
 
-uint64_t gThrottleRate;
+uint64_t gThrottleRate, gUnadjustedThrottleRate;
 
 static bool gThrottleRunning=false;
 static pthread_t gThrottleThreadId;
@@ -71,6 +71,7 @@ ThrottleInit()
 
     memset(&gThrottleData, 0, sizeof(gThrottleData));
     gThrottleRate=0;
+    gUnadjustedThrottleRate=0;
 
     pthread_create(&gThrottleThreadId, NULL,  &ThrottleThread, NULL);
 
@@ -85,7 +86,7 @@ ThrottleThread(
 {
     uint64_t tot_micros, tot_keys, tot_backlog, tot_compact;
     int replace_idx, loop;
-    uint64_t new_throttle;
+    uint64_t new_throttle, new_unadjusted;
     time_t now_seconds, cache_expire;
     struct timespec wait_time;
 
@@ -148,6 +149,11 @@ ThrottleThread(
             new_throttle /= 10000;  // remove *100 stuff
             if (0==new_throttle)
                 new_throttle=1;     // throttle must have an effect
+
+            new_unadjusted=(tot_micros*100) / tot_keys;
+            new_unadjusted /= 100;
+            if (0==new_unadjusted)
+                new_unadjusted=1;
         }   // if
 
 	// attempt to most recent level0
@@ -158,6 +164,11 @@ ThrottleThread(
             pthread_mutex_lock(&gThrottleMutex);
             new_throttle=(gThrottleData[0].m_Micros / gThrottleData[0].m_Keys)
 	      * (gThrottleData[0].m_Backlog / gThrottleData[0].m_Compactions);
+
+            new_unadjusted=(gThrottleData[0].m_Micros / gThrottleData[0].m_Keys);
+            if (0==new_unadjusted)
+                new_unadjusted=1;
+
             pthread_mutex_unlock(&gThrottleMutex);
 	}   // else if
         else
@@ -174,8 +185,11 @@ ThrottleThread(
         if (0==gThrottleRate)
             gThrottleRate=1;   // throttle must always have an effect
 
+        gUnadjustedThrottleRate=new_unadjusted;
+
         gPerfCounters->Set(ePerfThrottleGauge, gThrottleRate);
         gPerfCounters->Add(ePerfThrottleCounter, gThrottleRate*THROTTLE_SECONDS);
+        gPerfCounters->Set(ePerfThrottleUnadjusted, gUnadjustedThrottleRate);
 
         // prepare for next interval
         pthread_mutex_lock(&gThrottleMutex);
@@ -239,6 +253,7 @@ void SetThrottleWriteRate(uint64_t Micros, uint64_t Keys, bool IsLevel0, int Bac
 };
 
 uint64_t GetThrottleWriteRate() {return(gThrottleRate);};
+uint64_t GetUnadjustedThrottleWriteRate() {return(gUnadjustedThrottleRate);};
 
 void ThrottleShutdown()
 {

--- a/util/throttle.h
+++ b/util/throttle.h
@@ -35,6 +35,7 @@ void ThrottleInit();
 void SetThrottleWriteRate(uint64_t Micros, uint64_t Keys, bool IsLevel0, int Backlog);
 
 uint64_t GetThrottleWriteRate();
+uint64_t GetUnadjustedThrottleWriteRate();
 
 void ThrottleShutdown();
 


### PR DESCRIPTION
The branch contains four independent changes, but all related to the customer issue:
- Create alternate throttle value for single vnode usage
- Restore the IsTrivialMove() function so that some compactions are simply renames
- Correct Options::mmap_size usage so that write_buffer is not forced to 20Mbytes all the time
- Implement concept of mv-compress-bypass branch in current code to eliminate compression attempts known to fail

Detail description: https://github.com/basho/leveldb/wiki/mv-sequential-tuning
