### PR TITLE
Added explicit include of pthread.h

### DIFF
--- a/include/leveldb/env.h
+++ b/include/leveldb/env.h
@@ -17,6 +17,7 @@
 #include <string>
 #include <vector>
 #include <stdint.h>
+#include <pthread.h>
 #include "leveldb/perf_count.h"
 #include "leveldb/status.h"
 


### PR DESCRIPTION
This fix allows leveldb to build cleanly on FreeBSD 10, which ships clang as the default compiler.
