### PR TITLE
Include pthread.h and time.h to get leveldb to build on FreeBSD 10

### DIFF
--- a/include/leveldb/env.h
+++ b/include/leveldb/env.h
@@ -14,6 +14,7 @@
 #define STORAGE_LEVELDB_INCLUDE_ENV_H_
 
 #include <cstdarg>
+#include <pthread.h>
 #include <string>
 #include <vector>
 #include <stdint.h>

--- a/util/cache2.h
+++ b/util/cache2.h
@@ -24,6 +24,7 @@
 #define STORAGE_LEVELDB_INCLUDE_CACHE2_H_
 
 #include <stdint.h>
+#include <time.h>
 #include "leveldb/atomics.h"
 #include "leveldb/cache.h"
 #include "leveldb/options.h"


### PR DESCRIPTION
The current leveldb codebase, using the latest gcc and g++ compilers,
does not build successfully in FreeBSD 10. One will see errors such as:

  ./util/cache2.h:74:5: error: unknown type name 'time_t'
or
  ./include/leveldb/env.h:373:13: error: incomplete result type 'pthread'
  in function definition

Including the POSIX time.h and pthread.h header files yields a
successful build on FreeBSD 10.x releases.
