### PR TITLE
Set CC/C++ flags for FreeBSD

### DIFF
--- a/build_detect_platform
+++ b/build_detect_platform
@@ -87,6 +87,8 @@ case "$TARGET_OS" in
         PORT_FILE=port/port_posix.cc
         ;;
     FreeBSD)
+        CC=cc
+        CXX=c++
         PLATFORM=OS_FREEBSD
         COMMON_FLAGS="-fno-builtin-memcmp -D_REENTRANT -DOS_FREEBSD"
         PLATFORM_LDFLAGS="-lpthread"


### PR DESCRIPTION
This fixes the C++ compiler name issue in FreeBSD 10.0 and later (no g++ installed).
This will _not_ break the compiler issues in FreeBSD 9.x and earlier since in those versions the stock c++ are also aliased to g++.
This will also fix the issue in https://github.com/basho/eleveldb/issues/97 but more thorough testing is required.
