### PR TITLE
Create method to dynamically enable / disable performance counters

### DIFF
--- a/include/leveldb/perf_count.h
+++ b/include/leveldb/perf_count.h
@@ -238,6 +238,14 @@ enum PerformanceCountersEnum
     ePerfKey=41207          //!< random number as shared memory identifier
 };
 
+
+struct PerfCounterAttributes
+{
+    const char * m_PerfCounterName;  //!< text description
+    const bool m_PerfDiscretionary;  //!< true if ok to disable
+};  // PerfCounterAttributes
+
+
 //
 // Do NOT use virtual functions.  This structure will be aligned at different
 //  locations in multiple processes.  Things can get messy with virtuals.
@@ -253,7 +261,7 @@ protected:
 
     volatile uint64_t m_Counter[ePerfCountEnumSize];
 
-    static const char * m_PerfCounterNames[];
+    static const PerfCounterAttributes m_PerfCounterAttr[];
     static int m_PerfSharedId;
     static volatile uint64_t m_BogusCounter;  //!< for out of range GetPtr calls
 
@@ -295,6 +303,8 @@ public:
 };  // struct PerformanceCounters
 
 extern PerformanceCounters * gPerfCounters;
+
+extern bool gPerfCountersDisabled;
 
 }  // namespace leveldb
 

--- a/include/leveldb/perf_count.h
+++ b/include/leveldb/perf_count.h
@@ -304,7 +304,7 @@ public:
 
 extern PerformanceCounters * gPerfCounters;
 
-extern bool gPerfCountersDisabled;
+extern volatile bool gPerfCountersDisabled;
 
 }  // namespace leveldb
 

--- a/util/perf_count.cc
+++ b/util/perf_count.cc
@@ -527,7 +527,7 @@ PerformanceCounters * gPerfCounters(&LocalStartupCounters);
 
 
 
-    bool gPerfCountersDisabled=true;
+    volatile bool gPerfCountersDisabled=true;
     int PerformanceCounters::m_PerfSharedId=-1;
     int PerformanceCounters::m_LastError=0;
     volatile uint64_t PerformanceCounters::m_BogusCounter=0;

--- a/util/perf_count.cc
+++ b/util/perf_count.cc
@@ -52,7 +52,6 @@ namespace leveldb
 static PerformanceCounters LocalStartupCounters;
 PerformanceCounters * gPerfCounters(&LocalStartupCounters);
 
-
     SstCounters::SstCounters()
         : m_IsReadOnly(false),
           m_Version(eSstCountVersion),
@@ -346,7 +345,8 @@ PerformanceCounters * gPerfCounters(&LocalStartupCounters);
         uint64_t ret_val;
 
         ret_val=0;
-        if (Index<m_CounterSize)
+        if (Index<m_CounterSize
+            && (!gPerfCountersDisabled || !m_PerfCounterAttr[Index].m_PerfDiscretionary))
         {
             volatile uint64_t * val_ptr;
 
@@ -384,7 +384,8 @@ PerformanceCounters * gPerfCounters(&LocalStartupCounters);
         uint64_t ret_val;
 
         ret_val=0;
-        if (Index<m_CounterSize)
+        if (Index<m_CounterSize
+            && (!gPerfCountersDisabled || !m_PerfCounterAttr[Index].m_PerfDiscretionary))
         {
             volatile uint64_t * val_ptr;
 
@@ -423,7 +424,8 @@ PerformanceCounters * gPerfCounters(&LocalStartupCounters);
         uint64_t ret_val;
 
         ret_val=0;
-        if (Index<m_CounterSize)
+        if (Index<m_CounterSize
+            && (!gPerfCountersDisabled || !m_PerfCounterAttr[Index].m_PerfDiscretionary))
         {
             volatile uint64_t * val_ptr;
 
@@ -463,7 +465,8 @@ PerformanceCounters * gPerfCounters(&LocalStartupCounters);
         uint64_t ret_val;
 
         ret_val=0;
-        if (Index<m_CounterSize)
+        if (Index<m_CounterSize
+            && (!gPerfCountersDisabled || !m_PerfCounterAttr[Index].m_PerfDiscretionary))
         {
             ret_val=m_Counter[Index];
         }   // if
@@ -477,7 +480,8 @@ PerformanceCounters * gPerfCounters(&LocalStartupCounters);
         unsigned Index,
         uint64_t Amount)
     {
-        if (Index<m_CounterSize)
+        if (Index<m_CounterSize
+            && (!gPerfCountersDisabled || !m_PerfCounterAttr[Index].m_PerfDiscretionary))
         {
             volatile uint64_t * val_ptr;
 
@@ -513,7 +517,7 @@ PerformanceCounters * gPerfCounters(&LocalStartupCounters);
         const char * ret_ptr;
 
         if (Index<ePerfCountEnumSize)
-            ret_ptr=m_PerfCounterNames[Index];
+            ret_ptr=m_PerfCounterAttr[Index].m_PerfCounterName;
         else
             ret_ptr="???";
 
@@ -522,104 +526,106 @@ PerformanceCounters * gPerfCounters(&LocalStartupCounters);
     }   // PerformanceCounters::GetPtr
 
 
+
+    bool gPerfCountersDisabled=true;
     int PerformanceCounters::m_PerfSharedId=-1;
     int PerformanceCounters::m_LastError=0;
     volatile uint64_t PerformanceCounters::m_BogusCounter=0;
-    const char * PerformanceCounters::m_PerfCounterNames[]=
+    const PerfCounterAttributes PerformanceCounters::m_PerfCounterAttr[]=
     {
-        "ROFileOpen",
-        "ROFileClose",
-        "ROFileUnmap",
-        "RWFileOpen",
-        "RWFileClose",
-        "RWFileUnmap",
-        "ApiOpen",
-        "ApiGet",
-        "ApiWrite",
-        "WriteSleep",
-        "WriteWaitImm",
-        "WriteWaitLevel0",
-        "WriteNewMem",
-        "WriteError",
-        "WriteNoWait",
-        "GetMem",
-        "GetImm",
-        "GetVersion",
-        "SearchLevel[0]",
-        "SearchLevel[1]",
-        "SearchLevel[2]",
-        "SearchLevel[3]",
-        "SearchLevel[4]",
-        "SearchLevel[5]",
-        "SearchLevel[6]",
-        "TableCached",
-        "TableOpened",
-        "TableGet",
-        "BGCloseUnmap",
-        "BGCompactImm",
-        "BGNormal",
-        "BGCompactLevel0",
-        "BlockFiltered",
-        "BlockFilterFalse",
-        "BlockCached",
-        "BlockRead",
-        "BlockFilterRead",
-        "BlockValidGet",
-        "Debug[0]",
-        "Debug[1]",
-        "Debug[2]",
-        "Debug[3]",
-        "Debug[4]",
-        "ReadBlockError",
-        "DBIterNew",
-        "DBIterNext",
-        "DBIterPrev",
-        "DBIterSeek",
-        "DBIterSeekFirst",
-        "DBIterSeekLast",
-        "DBIterDelete",
-        "eleveldbDirect",
-        "eleveldbQueued",
-        "eleveldbDequeued",
-        "elevelRefCreate",
-        "elevelRefDelete",
-        "ThrottleGauge",
-        "ThrottleCounter",
-        "ThrottleMicros0",
-        "ThrottleKeys0",
-        "ThrottleBacklog0",
-        "ThrottleCompacts0",
-        "ThrottleMicros1",
-        "ThrottleKeys1",
-        "ThrottleBacklog1",
-        "ThrottleCompacts1",
-        "BGWriteError",
-        "ThrottleWait",
-        "ThreadError",
-        "BGImmDirect",
-        "BGImmQueued",
-        "BGImmDequeued",
-        "BGImmWeighted",
-        "BGUnmapDirect",
-        "BGUnmapQueued",
-        "BGUnmapDequeued",
-        "BGUnmapWeighted",
-        "BGLevel0Direct",
-        "BGLevel0Queued",
-        "BGLevel0Dequeued",
-        "BGLevel0Weighted",
-        "BGCompactDirect",
-        "BGCompactQueued",
-        "BGCompactDequeued",
-        "BGCompactWeighted",
-        "FileCacheInsert",
-        "FileCacheRemove",
-        "BlockCacheInsert",
-        "BlockCacheRemove",
-        "ApiDelete",
-        "BGMove",
-        "BGMoveFail",
-        "ThrottleUnadjusted"
+        {"ROFileOpen", true},
+        {"ROFileClose", true},
+        {"ROFileUnmap", true},
+        {"RWFileOpen", true},
+        {"RWFileClose", true},
+        {"RWFileUnmap", true},
+        {"ApiOpen", true},
+        {"ApiGet", true},
+        {"ApiWrite", true},
+        {"WriteSleep", true},
+        {"WriteWaitImm", false},
+        {"WriteWaitLevel0", false},
+        {"WriteNewMem", true},
+        {"WriteError", false},
+        {"WriteNoWait", true},
+        {"GetMem", true},
+        {"GetImm", true},
+        {"GetVersion", true},
+        {"SearchLevel[0]", true},
+        {"SearchLevel[1]", true},
+        {"SearchLevel[2]", true},
+        {"SearchLevel[3]", true},
+        {"SearchLevel[4]", true},
+        {"SearchLevel[5]", true},
+        {"SearchLevel[6]", true},
+        {"TableCached", true},
+        {"TableOpened", true},
+        {"TableGet", true},
+        {"BGCloseUnmap", true},
+        {"BGCompactImm", true},
+        {"BGNormal", true},
+        {"BGCompactLevel0", true},
+        {"BlockFiltered", true},
+        {"BlockFilterFalse", true},
+        {"BlockCached", true},
+        {"BlockRead", true},
+        {"BlockFilterRead", true},
+        {"BlockValidGet", true},
+        {"Debug[0]", true},
+        {"Debug[1]", true},
+        {"Debug[2]", true},
+        {"Debug[3]", true},
+        {"Debug[4]", true},
+        {"ReadBlockError", false},
+        {"DBIterNew", true},
+        {"DBIterNext", true},
+        {"DBIterPrev", true},
+        {"DBIterSeek", true},
+        {"DBIterSeekFirst", true},
+        {"DBIterSeekLast", true},
+        {"DBIterDelete", true},
+        {"eleveldbDirect", true},
+        {"eleveldbQueued", true},
+        {"eleveldbDequeued", true},
+        {"elevelRefCreate", true},
+        {"elevelRefDelete", true},
+        {"ThrottleGauge", true},
+        {"ThrottleCounter", true},
+        {"ThrottleMicros0", true},
+        {"ThrottleKeys0", true},
+        {"ThrottleBacklog0", true},
+        {"ThrottleCompacts0", true},
+        {"ThrottleMicros1", true},
+        {"ThrottleKeys1", true},
+        {"ThrottleBacklog1", true},
+        {"ThrottleCompacts1", true},
+        {"BGWriteError", false},
+        {"ThrottleWait", true},
+        {"ThreadError", false},
+        {"BGImmDirect", true},
+        {"BGImmQueued", true},
+        {"BGImmDequeued", true},
+        {"BGImmWeighted", true},
+        {"BGUnmapDirect", true},
+        {"BGUnmapQueued", true},
+        {"BGUnmapDequeued", true},
+        {"BGUnmapWeighted", true},
+        {"BGLevel0Direct", true},
+        {"BGLevel0Queued", true},
+        {"BGLevel0Dequeued", true},
+        {"BGLevel0Weighted", true},
+        {"BGCompactDirect", true},
+        {"BGCompactQueued", true},
+        {"BGCompactDequeued", true},
+        {"BGCompactWeighted", true},
+        {"FileCacheInsert", true},
+        {"FileCacheRemove", true},
+        {"BlockCacheInsert", true},
+        {"BlockCacheRemove", true},
+        {"ApiDelete", true},
+        {"BGMove", true},
+        {"BGMoveFail", false},
+        {"ThrottleUnadjusted", true}
     };
 
 
@@ -635,7 +641,7 @@ PerformanceCounters * gPerfCounters(&LocalStartupCounters);
         {
             for (loop=0; loop<ePerfCountEnumSize && -1==index; ++loop)
             {
-                if (0==strcmp(m_PerfCounterNames[loop], Name))
+                if (0==strcmp(m_PerfCounterAttr[loop].m_PerfCounterName, Name))
                     index=loop;
             }   // loop
         }   // if
@@ -653,7 +659,8 @@ PerformanceCounters * gPerfCounters(&LocalStartupCounters);
 
         for (loop=0; loop<ePerfCountEnumSize; ++loop)
         {
-            printf("  %s: %" PRIu64 "\n", m_PerfCounterNames[loop], m_Counter[loop]);
+            printf("  %s: %" PRIu64 "\n",
+                   m_PerfCounterAttr[loop].m_PerfCounterName, m_Counter[loop]);
         }   // loop
     };  // Dump
 

--- a/util/perf_count.cc
+++ b/util/perf_count.cc
@@ -465,8 +465,7 @@ PerformanceCounters * gPerfCounters(&LocalStartupCounters);
         uint64_t ret_val;
 
         ret_val=0;
-        if (Index<m_CounterSize
-            && (!gPerfCountersDisabled || !m_PerfCounterAttr[Index].m_PerfDiscretionary))
+        if (Index<m_CounterSize)
         {
             ret_val=m_Counter[Index];
         }   // if

--- a/util/throttle.cc
+++ b/util/throttle.cc
@@ -92,6 +92,17 @@ ThrottleThread(
 
     while(gThrottleRunning)
     {
+        //
+        // This is code polls for existance of /etc/riak/perf_counters and sets
+        //  the global gPerfCountersDisabled accordingly.
+        //  Sure, there should be a better place for this code.  But fits here nicely today.
+        //
+        ret_val=access("/etc/riak/perf_counters", F_OK);
+        gPerfCountersDisabled=(-1==ret_val);
+
+        //
+        // start actual throttle work
+        //
         pthread_mutex_lock(&gThrottleMutex);
 
         // sleep 1 minute
@@ -205,14 +216,6 @@ ThrottleThread(
             DBList()->ScanDBs(true,&DBImpl::PurgeExpiredFileCache);
             DBList()->ScanDBs(false, &DBImpl::PurgeExpiredFileCache);
         }   // if
-
-        //
-        // This is code polls for existance of /etc/riak/perf_counters and sets
-        //  the global gPerfCountersDisabled accordingly.
-        //  Sure, there should be a better place for this code.  But fits here nicely today.
-        //
-        ret_val=access("/etc/riak/perf_counters", F_OK);
-        gPerfCountersDisabled=(-1==ret_val);
     }   // while
 
     return(NULL);

--- a/util/throttle.h
+++ b/util/throttle.h
@@ -26,10 +26,6 @@
 namespace leveldb
 {
 
-extern pthread_rwlock_t gThreadLock0;
-extern pthread_rwlock_t gThreadLock1;
-
-
 void ThrottleInit();
 
 void SetThrottleWriteRate(uint64_t Micros, uint64_t Keys, bool IsLevel0, int Backlog);


### PR DESCRIPTION
The leveldb performance counters now default to a disabled state. They are enabled when the file "/etc/riak/perf_counters" exists. The content of the file is irrelevant. leveldb's background thread polls for the file once a minute. This allows enabling and disabling the performance counters without restarting leveldb / Riak.

Detailed discussion is here:

   https://github.com/basho/leveldb/wiki/mv-perfcounter-disable
