### PR TITLE
Reactivate Google's PickLevelForMemTableOutput()

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -1863,7 +1863,9 @@ Status DBImpl::Write(const WriteOptions& options, WriteBatch* my_batch) {
 
 // REQUIRES: Writer list must be non-empty
 // REQUIRES: First writer must have a non-NULL batch
+// REQUIRES: mutex_ is held
 WriteBatch* DBImpl::BuildBatchGroup(Writer** last_writer) {
+  mutex_.AssertHeld();
   assert(!writers_.empty());
   Writer* first = writers_.front();
   WriteBatch* result = first->batch;

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -735,13 +735,31 @@ Status DBImpl::WriteLevel0Table(volatile MemTable* mem, VersionEdit* edit,
             new_name=TableFileName(options_, meta.number, level);
             move_s=env_->RenameFile(old_name, new_name);
 
-            // argh!  logging while holding mutex ... cannot release
             if (move_s.ok())
+            {
+                // builder already added file to table_cache with 2 references and
+                //  marked as level 0 (used by cache warming) ... going to remove from cache
+                //  and add again correctly
+                table_cache_->Evict(meta.number, true);
+                meta.level=level;
+
+                // sadly, we must hold the mutex during this file open
+                //  since operating in non-overlapped level
+                Iterator* it=table_cache_->NewIterator(ReadOptions(),
+                                                       meta.number,
+                                                       meta.file_size,
+                                                       meta.level);
+                delete it;
+
+                // argh!  logging while holding mutex ... cannot release
                 Log(options_.info_log, "Level-0 table #%llu:  moved to level %d",
                     (unsigned long long) meta.number,
                     level);
+            }   // if
             else
+            {
                 level=0;
+            }   // else
         }   // if
     }
 
@@ -758,7 +776,7 @@ Status DBImpl::WriteLevel0Table(volatile MemTable* mem, VersionEdit* edit,
   // Riak adds extra reference to file, must remove it
   //  in this race condition upon close
   if (s.ok() && shutting_down_.Acquire_Load()) {
-      versions_->GetTableCache()->Evict(meta.number, true);
+      table_cache_->Evict(meta.number, versions_->IsLevelOverlapped(level));
   }
 
   return s;

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -1199,26 +1199,27 @@ TEST(DBTest, DeletionMarkers1) {
   Put("foo", "v1");
   ASSERT_OK(dbfull()->TEST_CompactMemTable());
   const int last = config::kMaxMemCompactLevel;
-  //ASSERT_EQ(NumTableFilesAtLevel(last), 1);   // foo => v1 is now in last level
+  ASSERT_EQ(NumTableFilesAtLevel(last), 1);   // foo => v1 is now in last level
 
   // Place a table at level last-1 to prevent merging with preceding mutation
   Put("a", "begin");
   Put("z", "end");
   dbfull()->TEST_CompactMemTable();
-  //ASSERT_EQ(NumTableFilesAtLevel(last), 1);
-  //ASSERT_EQ(NumTableFilesAtLevel(last-1), 1);
+  ASSERT_EQ(NumTableFilesAtLevel(last), 1);
+  ASSERT_EQ(NumTableFilesAtLevel(last-1), 1);
 
   Delete("foo");
   Put("foo", "v2");
   ASSERT_EQ(AllEntriesFor("foo"), "[ v2, DEL, v1 ]");
-  ASSERT_OK(dbfull()->TEST_CompactMemTable());  // Moves to level last-2
+  ASSERT_OK(dbfull()->TEST_CompactMemTable());  // stays at level 0
   ASSERT_EQ(AllEntriesFor("foo"), "[ v2, v1 ]"); // riak 1.3, DEL merged out by BuildTable
   Slice z("z");
-  dbfull()->TEST_CompactRange(last-2, NULL, &z);
+  dbfull()->TEST_CompactRange(0, NULL, &z);
+  dbfull()->TEST_CompactRange(1, NULL, &z);
   // DEL eliminated, but v1 remains because we aren't compacting that level
   // (DEL can be eliminated because v2 hides v1).
-  //ASSERT_EQ(AllEntriesFor("foo"), "[ v2, v1 ]"); Riak 1.4 has merged to level 1
-  //dbfull()->TEST_CompactRange(last-1, NULL, NULL);
+  ASSERT_EQ(AllEntriesFor("foo"), "[ v2, v1 ]"); // Riak 1.4 has merged to level 1
+  dbfull()->TEST_CompactRange(last-1, NULL, NULL);
   // Merging last-1 w/ last, so we are the base level for "foo", so
   // DEL is removed.  (as is v1).
   ASSERT_EQ(AllEntriesFor("foo"), "[ v2 ]");
@@ -1228,20 +1229,20 @@ TEST(DBTest, DeletionMarkers2) {
   Put("foo", "v1");
   ASSERT_OK(dbfull()->TEST_CompactMemTable());
   const int last = config::kMaxMemCompactLevel;
-  ASSERT_EQ(NumTableFilesAtLevel(0), 1);   // foo => v1 is now in last level
+  ASSERT_EQ(NumTableFilesAtLevel(last), 1);   // foo => v1 is now in last level
   dbfull()->TEST_CompactRange(0, NULL, NULL);
-  ASSERT_EQ(NumTableFilesAtLevel(1), 1);   // foo => v1 is now in last level
-  ASSERT_EQ(NumTableFilesAtLevel(0), 0);
+  ASSERT_EQ(NumTableFilesAtLevel(last), 1);   // foo => v1 is now in last level
+  ASSERT_EQ(NumTableFilesAtLevel(last-1), 0);
 
   // Place a table at level last-1 to prevent merging with preceding mutation
   Put("a", "begin");
   Put("z", "end");
-  dbfull()->TEST_CompactMemTable();
-  ASSERT_EQ(NumTableFilesAtLevel(0), 1);
+  dbfull()->TEST_CompactMemTable(); // goes to last-1
+  ASSERT_EQ(NumTableFilesAtLevel(last-1), 1);
 
   Delete("foo");
   ASSERT_EQ(AllEntriesFor("foo"), "[ DEL, v1 ]");
-  ASSERT_OK(dbfull()->TEST_CompactMemTable());  // Moves to level last-2
+  ASSERT_OK(dbfull()->TEST_CompactMemTable());  // Moves to level 0
   ASSERT_EQ(AllEntriesFor("foo"), "[ DEL, v1 ]");
   dbfull()->TEST_CompactRange(0, NULL, NULL);   // Riak overlaps level 1
   // DEL kept: "last" file overlaps
@@ -1249,7 +1250,7 @@ TEST(DBTest, DeletionMarkers2) {
   // Merging last-1 w/ last, so we are the base level for "foo", so
   // DEL is removed.  (as is v1).
   dbfull()->TEST_CompactRange(1, NULL, NULL);
-  ASSERT_EQ(AllEntriesFor("foo"), "[ DEL ]");
+  ASSERT_EQ(AllEntriesFor("foo"), "[ DEL, v1 ]");
 
   dbfull()->TEST_CompactRange(2, NULL, NULL);
   ASSERT_EQ(AllEntriesFor("foo"), "[ ]");
@@ -1257,7 +1258,7 @@ TEST(DBTest, DeletionMarkers2) {
 
 TEST(DBTest, OverlapInLevel0) {
   do {
-    ASSERT_EQ(config::kMaxMemCompactLevel, 2) << "Fix test to match config";
+    ASSERT_EQ(config::kMaxMemCompactLevel, 3) << "Fix test to match config";
 
     // Fill levels 1 and 2 to disable the pushing of new memtables to levels > 0.
     ASSERT_OK(Put("100", "v100"));
@@ -1269,7 +1270,7 @@ TEST(DBTest, OverlapInLevel0) {
     ASSERT_OK(Delete("999"));
     dbfull()->TEST_CompactMemTable();
     dbfull()->TEST_CompactRange(0, NULL, NULL);
-    ASSERT_EQ("0,1,1", FilesPerLevel());
+    ASSERT_EQ("0,0,1,1", FilesPerLevel());
 
     // Make files spanning the following ranges in level-0:
     //  files[0]  200 .. 900
@@ -1282,7 +1283,7 @@ TEST(DBTest, OverlapInLevel0) {
     ASSERT_OK(Put("600", "v600"));
     ASSERT_OK(Put("900", "v900"));
     dbfull()->TEST_CompactMemTable();
-    ASSERT_EQ("2,1,1", FilesPerLevel());
+    ASSERT_EQ("2,0,1,1", FilesPerLevel());
 
     // Compact away the placeholder files we created initially
     dbfull()->TEST_CompactRange(1, NULL, NULL);
@@ -1421,40 +1422,37 @@ TEST(DBTest, CustomComparator) {
 }
 
 TEST(DBTest, ManualCompaction) {
-  ASSERT_EQ(config::kMaxMemCompactLevel, 2)
+  ASSERT_EQ(config::kMaxMemCompactLevel, 3)
       << "Need to update this test to match kMaxMemCompactLevel";
 
   MakeTables(3, "p", "q");
-  ASSERT_EQ("3", FilesPerLevel());
+  ASSERT_EQ("1,0,1,1", FilesPerLevel());
 
   // Compaction range falls before files
-  // (Basho compacts all at zero no matter what)
   Compact("", "c");
-  //ASSERT_EQ("3", FilesPerLevel());
-  ASSERT_EQ("0,1", FilesPerLevel());
+  ASSERT_EQ("0,1,1,1", FilesPerLevel());
 
   // Compaction range falls after files
   Compact("r", "z");
-  //ASSERT_EQ("3", FilesPerLevel());
-  ASSERT_EQ("0,1", FilesPerLevel());
+  ASSERT_EQ("0,1,1,1", FilesPerLevel());
 
   // Compaction range overlaps files
   Compact("p1", "p9");
-  ASSERT_EQ("0,1", FilesPerLevel());
+  ASSERT_EQ("0,0,0,1", FilesPerLevel());
 
   // Populate a different range
   MakeTables(3, "c", "e");
-  ASSERT_EQ("3,1", FilesPerLevel());
+  ASSERT_EQ("1,0,1,2", FilesPerLevel());
 
   // Compact just the new range
   Compact("b", "f");
-  ASSERT_EQ("0,2", FilesPerLevel());
+  ASSERT_EQ("0,0,0,2", FilesPerLevel());
 
   // Compact all
   MakeTables(1, "a", "z");
-  ASSERT_EQ("1,2", FilesPerLevel());
+  ASSERT_EQ("0,0,1,2", FilesPerLevel());
   db_->CompactRange(NULL, NULL);
-  ASSERT_EQ("0,3", FilesPerLevel());
+  ASSERT_EQ("0,0,0,1", FilesPerLevel());
 }
 
 TEST(DBTest, DBOpen_Options) {

--- a/db/dbformat.h
+++ b/db/dbformat.h
@@ -44,7 +44,8 @@ static const size_t kL0_StopWritesTrigger = 12;
 // expensive manifest file operations.  We do not push all the way to
 // the largest level since that can generate a lot of wasted disk
 // space if the same key space is being repeatedly overwritten.
-static const int kMaxMemCompactLevel = 2;
+// Basho: push to kNumOverlapLevels +1 ... beyond "landing level"
+static const int kMaxMemCompactLevel = 3;
 
 }  // namespace config
 

--- a/db/dbformat.h
+++ b/db/dbformat.h
@@ -45,7 +45,7 @@ static const size_t kL0_StopWritesTrigger = 12;
 // the largest level since that can generate a lot of wasted disk
 // space if the same key space is being repeatedly overwritten.
 // Basho: push to kNumOverlapLevels +1 ... beyond "landing level"
-static const int kMaxMemCompactLevel = 3;
+static const int kMaxMemCompactLevel = kNumOverlapLevels+1;
 
 }  // namespace config
 

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -478,7 +478,7 @@ int Version::PickLevelForMemTableOutput(
     const Slice& largest_user_key,
     const int level_limit) {
   int level = 0;
-#if 1
+
 // test if level 1 m_OverlappedFiles is false, proceded only then
   if (!OverlapInLevel(0, &smallest_user_key, &largest_user_key)) {
     // Push to next level if there is no overlap in next level,
@@ -491,7 +491,7 @@ int Version::PickLevelForMemTableOutput(
         break;
       }
       GetOverlappingInputs(level + 2, &start, &limit, &overlaps);
-      const int64_t sum = TotalFileSize(overlaps);
+      const uint64_t sum = TotalFileSize(overlaps);
       if (sum > gLevelTraits[level].m_MaxGrandParentOverlapBytes) {
         break;
       }
@@ -502,7 +502,7 @@ int Version::PickLevelForMemTableOutput(
     if (gLevelTraits[level].m_OverlappedFiles)
         level=0;
   }
-#endif
+
   return level;
 }
 

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -102,7 +102,8 @@ class Version {
   // Return the level at which we should place a new memtable compaction
   // result that covers the range [smallest_user_key,largest_user_key].
   int PickLevelForMemTableOutput(const Slice& smallest_user_key,
-                                 const Slice& largest_user_key);
+                                 const Slice& largest_user_key,
+                                 const int level_limit);
 
   size_t NumFiles(int level) const { return files_[level].size(); }
 
@@ -316,6 +317,8 @@ class VersionSet {
   void SetCompactionDone(int level)
   {   m_CompactionStatus[level].m_Running=false;
       m_CompactionStatus[level].m_Submitted=false;}
+
+  bool NeighborCompactionsQuiet(int level);
 
  private:
   class Builder;

--- a/util/env_posix.cc
+++ b/util/env_posix.cc
@@ -853,13 +853,6 @@ class PosixEnv : public Env {
     }
   }
 
-  // BGThread() is the body of the background thread
-  void BGThread();
-  static void* BGThreadWrapper(void* arg) {
-    reinterpret_cast<PosixEnv*>(arg)->BGThread();
-    return NULL;
-  }
-
   size_t page_size_;
   pthread_mutex_t mu_;
   pthread_cond_t bgsignal_;


### PR DESCRIPTION
This routine used to "be in the way" when efforts focused on random data ingest.  Now, it has new relevance as Riak's handoff and other sequential features come into play.

Detail discussion is here:

https://github.com/basho/leveldb/wiki/mv-initial-level-fix
