### PR TITLE
Mv timed grooming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ db_bench
 leveldb_repair
 perf_dump
 sst_scan
+sst_rewrite
 *~

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -928,7 +928,7 @@ void DBImpl::BackgroundCall2(
 
   if (!shutting_down_.Acquire_Load()) {
     Status s = BackgroundCompaction(Compact);
-    if (!s.ok()) {
+    if (!s.ok() && !shutting_down_.Acquire_Load()) {
       // Wait a little bit before retrying background compaction in
       // case this is an environmental problem and we do not want to
       // chew up resources for failed compactions for the duration of
@@ -969,7 +969,7 @@ DBImpl::BackgroundImmCompactCall() {
 
   if (!shutting_down_.Acquire_Load()) {
     s = CompactMemTable();
-    if (!s.ok()) {
+    if (!s.ok() && !shutting_down_.Acquire_Load()) {
       // Wait a little bit before retrying background compaction in
       // case this is an environmental problem and we do not want to
       // chew up resources for failed compactions for the duration of

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -947,7 +947,7 @@ void DBImpl::BackgroundCall2(
   }   // else
   bg_compaction_scheduled_ = false;
   --running_compactions_;
-  versions_->SetCompactionDone(level);
+  versions_->SetCompactionDone(level, env_->NowMicros());
 
   // Previous compaction may have produced too many files in a level,
   // so reschedule another compaction if needed.

--- a/db/dbformat.h
+++ b/db/dbformat.h
@@ -31,6 +31,8 @@ static const size_t kL0_CompactionTrigger = 6;
 // Level-0 (any overlapped level) number of files where a grooming
 //     compaction could start
 static const size_t kL0_GroomingTrigger = 4;
+static const size_t kL0_GroomingTrigger10min = 2;
+static const size_t kL0_GroomingTrigger20min = 1;
 
 // Soft limit on number of level-0 files.  We slow down writes at this point.
 static const size_t kL0_SlowdownWritesTrigger = 8;

--- a/db/dbformat.h
+++ b/db/dbformat.h
@@ -34,6 +34,10 @@ static const size_t kL0_GroomingTrigger = 4;
 static const size_t kL0_GroomingTrigger10min = 2;
 static const size_t kL0_GroomingTrigger20min = 1;
 
+// ... time limits in microseconds
+static const size_t kL0_Grooming10minMicros = 10 * 60 * 1000000;
+static const size_t kL0_Grooming20minMicros = 20 * 60 * 1000000;
+
 // Soft limit on number of level-0 files.  We slow down writes at this point.
 static const size_t kL0_SlowdownWritesTrigger = 8;
 

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1129,15 +1129,23 @@ VersionSet::Finalize(Version* v)
         if (compact_ok)
         {
             size_t grooming_trigger;
+            uint64_t elapsed_micros;
+
+            // some platforms use gettimeofday() which can move backward
+            if ( m_CompactionStatus[level].m_LastCompaction < micros_now 
+                 && 0 != m_CompactionStatus[level].m_LastCompaction)
+                elapsed_micros=micros_now - m_CompactionStatus[level].m_LastCompaction;
+            else
+                elapsed_micros=0;
 
             // which grooming trigger point?  based upon how long
             //  since last compaction on this level
             //   - less than 10 minutes?
-            if (micros_now<(m_CompactionStatus[level].m_LastCompaction + (1000000 * 60 *10)))
+            if (elapsed_micros < config::kL0_Grooming10minMicros)
                 grooming_trigger=config::kL0_GroomingTrigger;
 
             //   - less than 20 minutes?
-            else if (micros_now<(m_CompactionStatus[level].m_LastCompaction + (1000000 * 60 *20)))
+            else if (elapsed_micros < config::kL0_Grooming20minMicros)
                 grooming_trigger=config::kL0_GroomingTrigger10min;
 
             //   - more than 20 minutes

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -316,7 +316,7 @@ class VersionSet {
   void SetCompactionDone(int level)
   {   m_CompactionStatus[level].m_Running=false;
       m_CompactionStatus[level].m_Submitted=false;
-      m_CompactionStatus[level].m_LastCompaction=env_->NowMicros(); }
+      m_CompactionStatus[level].m_LastCompaction=0; }
 
   bool NeighborCompactionsQuiet(int level);
 

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -313,10 +313,10 @@ class VersionSet {
   void SetCompactionRunning(int level)
   {m_CompactionStatus[level].m_Running=true;}
 
-  void SetCompactionDone(int level)
+  void SetCompactionDone(int level, uint64_t Now)
   {   m_CompactionStatus[level].m_Running=false;
       m_CompactionStatus[level].m_Submitted=false;
-      m_CompactionStatus[level].m_LastCompaction=0; }
+      m_CompactionStatus[level].m_LastCompaction=Now; }
 
   bool NeighborCompactionsQuiet(int level);
 
@@ -378,7 +378,7 @@ class VersionSet {
       uint64_t m_LastCompaction; //!<NowMicros() when last compaction completed
 
       CompactionStatus_s()
-      : m_Submitted(false), m_Running(false), m_LastCompaction(Env::Default()->NowMicros())
+      : m_Submitted(false), m_Running(false), m_LastCompaction(0)
       {};
   } m_CompactionStatus[config::kNumLevels];
 

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -315,7 +315,8 @@ class VersionSet {
 
   void SetCompactionDone(int level)
   {   m_CompactionStatus[level].m_Running=false;
-      m_CompactionStatus[level].m_Submitted=false;}
+      m_CompactionStatus[level].m_Submitted=false;
+      m_CompactionStatus[level].m_LastCompaction=env_->NowMicros(); }
 
   bool NeighborCompactionsQuiet(int level);
 
@@ -374,9 +375,10 @@ class VersionSet {
   {
       bool m_Submitted;     //!< level submitted to hot thread pool
       bool m_Running;       //!< thread actually running compaction
+      uint64_t m_LastCompaction; //!<NowMicros() when last compaction completed
 
       CompactionStatus_s()
-      : m_Submitted(false), m_Running(false)
+      : m_Submitted(false), m_Running(false), m_LastCompaction(Env::Default()->NowMicros())
       {};
   } m_CompactionStatus[config::kNumLevels];
 

--- a/util/env_posix.cc
+++ b/util/env_posix.cc
@@ -1094,9 +1094,6 @@ void Env::Shutdown()
 {
     if (started)
     {
-        delete default_env;
-        default_env=NULL;
-
         ThrottleShutdown();
     }   // if
 
@@ -1113,6 +1110,13 @@ void Env::Shutdown()
 
     delete gCompactionThreads;
     gCompactionThreads=NULL;
+
+    if (started)
+    {
+        delete default_env;
+        default_env=NULL;
+    }   // if
+
 
     // wait until compaction threads complete before
     //  releasing comparator object (else segfault possible)

--- a/util/flexcache.h
+++ b/util/flexcache.h
@@ -25,18 +25,18 @@
 #ifndef STORAGE_LEVELDB_INCLUDE_FLEXCACHE_H_
 #define STORAGE_LEVELDB_INCLUDE_FLEXCACHE_H_
 
-namespace leveldb 
+namespace leveldb
 {
 
 // Constants declared in style of db/dbformat.h
 namespace flex
 {
 
-   static const uint64_t kRlimSizeIsSmall = 2*1024*1024*1024L;  // above 2G is lots of ram
-   static const uint64_t kRlimSmall = 256*1024*1024L;
-   static const uint64_t kRlimLargeReserve = 1024*1024*1024L;
-   static const uint64_t kDefaultMemory = 340*1024*1024L;
-   static const uint64_t kMinimumDBMemory = 10*1024*1024L;
+   static const uint64_t kRlimSizeIsSmall = 2*1024*1024*1024ULL;  // above 2G is lots of ram
+   static const uint64_t kRlimSmall = 256*1024*1024ULL;
+   static const uint64_t kRlimLargeReserve = 1024*1024*1024ULL;
+   static const uint64_t kDefaultMemory = 340*1024*1024ULL;
+   static const uint64_t kMinimumDBMemory = 10*1024*1024ULL;
 
 }   // namespace flex
 

--- a/util/thread_tasks.cc
+++ b/util/thread_tasks.cc
@@ -55,6 +55,8 @@ GroomingPollTask::operator()()
     // "false" only scan user databases, not internal
     if (0==gCompactionThreads->m_WorkQueueAtomic)
         DBList()->ScanDBs(false, &DBImpl::CheckAvailableCompactions);
+    if (0==gCompactionThreads->m_WorkQueueAtomic)
+        DBList()->ScanDBs(true, &DBImpl::CheckAvailableCompactions);
 
 }   // GroomingPollTask::operator()
 

--- a/util/throttle.cc
+++ b/util/throttle.cc
@@ -235,6 +235,13 @@ ThrottleThread(
             DBList()->ScanDBs(true,&DBImpl::PurgeExpiredFileCache);
             DBList()->ScanDBs(false, &DBImpl::PurgeExpiredFileCache);
         }   // if
+
+        // nudge compaction logic of potential grooming
+        if (0==gCompactionThreads->m_WorkQueueAtomic)  // user databases
+            DBList()->ScanDBs(false, &DBImpl::CheckAvailableCompactions);
+        if (0==gCompactionThreads->m_WorkQueueAtomic)  // internal databases
+            DBList()->ScanDBs(true, &DBImpl::CheckAvailableCompactions);
+
     }   // while
 
     return(NULL);


### PR DESCRIPTION
This branch initiates smaller compaction sets in levels 0 and 1 based upon elapsed time.  This is to improve read latencies in datasets with small to medium write loads.  

See https://github.com/basho/leveldb/wiki/mv-timed-grooming for details.
