### PR TITLE
Cleaned up most but not all clang warnings.

### DIFF
--- a/db/dbformat.h
+++ b/db/dbformat.h
@@ -51,7 +51,7 @@ static const size_t kL0_StopWritesTrigger = 12;
 // the largest level since that can generate a lot of wasted disk
 // space if the same key space is being repeatedly overwritten.
 // Basho: push to kNumOverlapLevels +1 ... beyond "landing level"
-static const int kMaxMemCompactLevel = kNumOverlapLevels+1;
+static const unsigned kMaxMemCompactLevel = kNumOverlapLevels+1;
 
 }  // namespace config
 

--- a/db/repair.cc
+++ b/db/repair.cc
@@ -54,8 +54,6 @@ class Repairer {
         icmp_(options.comparator),
         ipolicy_(options.filter_policy),
         owns_info_log_(options_.info_log != options.info_log),
-        owns_cache_(options_.block_cache != options.block_cache),
-        has_level_dirs_(false),
         db_lock_(NULL),
         next_file_number_(1)
   {
@@ -170,8 +168,6 @@ class Repairer {
   InternalKeyComparator const icmp_;
   InternalFilterPolicy const ipolicy_;
   bool owns_info_log_;
-  bool owns_cache_;
-  bool has_level_dirs_;
   FileLock* db_lock_;
   TableCache* table_cache_;
   VersionEdit edit_;

--- a/db/skiplist.h
+++ b/db/skiplist.h
@@ -408,11 +408,11 @@ SkipList<Key,Comparator>::SkipList(Comparator cmp, Arena* arena)
     : compare_(cmp),
       arena_(arena),
       head_(NewNode(0 /* any key will do */, kMaxHeight)),
+      max_height_(reinterpret_cast<void*>(1)),
+      rnd_(0xdeadbeef),
       tail_(NULL),
       tailHeight_(0),
-      sequentialInsertMode_(true),
-      max_height_(reinterpret_cast<void*>(1)),
-      rnd_(0xdeadbeef) {
+      sequentialInsertMode_(true) {
   for (int i = 0; i < kMaxHeight; i++) {
     head_->SetNext(i, NULL);
     tailPrev_[i] = NULL;

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -76,20 +76,6 @@ static int64_t TotalFileSize(const std::vector<FileMetaData*>& files) {
   return sum;
 }
 
-namespace {
-std::string IntSetToString(const std::set<uint64_t>& s) {
-  std::string result = "{";
-  for (std::set<uint64_t>::const_iterator it = s.begin();
-       it != s.end();
-       ++it) {
-    result += (result.size() > 1) ? "," : "";
-    result += NumberToString(*it);
-  }
-  result += "}";
-  return result;
-}
-}  // namespace
-
 Version::~Version() {
   assert(refs_ == 0);
 

--- a/include/leveldb/env.h
+++ b/include/leveldb/env.h
@@ -25,7 +25,7 @@ namespace leveldb {
 
 class AppendableFile;
 class FileLock;
-class Options;
+struct Options;
 class Logger;
 class RandomAccessFile;
 class SequentialFile;

--- a/util/env_posix.cc
+++ b/util/env_posix.cc
@@ -857,18 +857,15 @@ class PosixEnv : public Env {
   // Entry per Schedule() call
   struct BGItem { void* arg; void (*function)(void*); int priority;};
 
-  volatile uint64_t write_rate_usec_; // recently experienced average time to
-                                      // write one key during background compaction
-
 };
 
 
 PosixEnv::PosixEnv() : page_size_(getpagesize()),
-                       clock_res_(1), write_rate_usec_(0)
+                       clock_res_(1)
 {
-  struct timespec ts;
 
 #if _POSIX_TIMERS >= 200801L
+  struct timespec ts;
   clock_getres(CLOCK_MONOTONIC, &ts);
   clock_res_=ts.tv_sec*1000000+ts.tv_nsec/1000;
   if (0==clock_res_)


### PR DESCRIPTION
This PR removes some unused code that Clang identifies in its build of the leveldb source tree.

It also changes the forward declaration in env.h of the Options type from class to struct, which remove the majority of the warnings from the build.

Still using deprecated semaphore APIs on Darwin, but that is a more extensive change to make.
