### PR TITLE
pp bugfix freebsd compiler issues

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -716,7 +716,7 @@ Status DBImpl::WriteLevel0Table(volatile MemTable* mem, VersionEdit* edit,
     const Slice max_user_key = meta.largest.user_key();
     if (base != NULL) {
         int level_limit;
-        if (0!=options_.tiered_slow_level && (options_.tiered_slow_level-1)<config::kMaxMemCompactLevel)
+        if (0!=options_.tiered_slow_level && (options_.tiered_slow_level-1)<static_cast<unsigned>(config::kMaxMemCompactLevel))
             level_limit=options_.tiered_slow_level-1;
         else
             level_limit=config::kMaxMemCompactLevel;

--- a/db/skiplist.h
+++ b/db/skiplist.h
@@ -510,7 +510,7 @@ bool SkipList<Key,Comparator>::Valid() const
 
   // Ensure that the list is properly sorted; use an iterator for this check
   const Key* pPrevKey = NULL;
-  SkipList<Key, Comparator>::Iterator iter(this);
+  typename SkipList<Key, Comparator>::Iterator iter(this);
   for ( iter.SeekToFirst(); iter.Valid(); iter.Next() ) {
     if ( pPrevKey != NULL ) {
       if ( compare_( *pPrevKey, iter.key() ) >= 0 ) {


### PR DESCRIPTION
The pp-bugfix-freebsd-compiler-issues branch fixes an issue found only when compiling on FreeBSD. The FreeBSD build machine build-freebsd-9.2.bos1 uses a fairly old version of gcc, which chokes when compiling recent changes to db/skiplist.h.

The issue with building on FreeBSD was reported here: https://github.com/basho/riak_pipe/pull/102#issuecomment-156502047

While in the leveldb code on FreeBSD, I also fixed a compiler warning about 'signed vs. unsigned' comparisons in db/db_impl.cc.
