### PR TITLE
Fix then disable timed grooming

### DIFF
--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1124,6 +1124,9 @@ VersionSet::Finalize(Version* v)
             else
                 elapsed_micros=0;
 
+            // reevaluating timed grooming ... seems to crush caching
+            elapsed_micros=0;
+
             // which grooming trigger point?  based upon how long
             //  since last compaction on this level
             //   - less than 10 minutes?

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1125,6 +1125,8 @@ VersionSet::Finalize(Version* v)
                 elapsed_micros=0;
 
             // reevaluating timed grooming ... seems to crush caching
+            //  this disables the code but leaves it in place for future
+            //  reuse after block cache flushing impact addressed
             elapsed_micros=0;
 
             // which grooming trigger point?  based upon how long

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -316,9 +316,12 @@ class VersionSet {
   void SetCompactionDone(int level, uint64_t Now)
   {   m_CompactionStatus[level].m_Running=false;
       m_CompactionStatus[level].m_Submitted=false;
-      m_CompactionStatus[level].m_LastCompaction=Now; 
+      // must set both source and destination.  otherwise
+      //  destination might immediately decide it needs a
+      //  timed grooming too ... defeating idea to spreadout the groomings
+      m_CompactionStatus[level].m_LastCompaction=Now;
       if ((level+1)<config::kNumLevels)
-          m_CompactionStatus[level+1].m_LastCompaction=Now; 
+          m_CompactionStatus[level+1].m_LastCompaction=Now;
   }
 
   bool NeighborCompactionsQuiet(int level);

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -316,7 +316,10 @@ class VersionSet {
   void SetCompactionDone(int level, uint64_t Now)
   {   m_CompactionStatus[level].m_Running=false;
       m_CompactionStatus[level].m_Submitted=false;
-      m_CompactionStatus[level].m_LastCompaction=Now; }
+      m_CompactionStatus[level].m_LastCompaction=Now; 
+      if ((level+1)<config::kNumLevels)
+          m_CompactionStatus[level+1].m_LastCompaction=Now; 
+  }
 
   bool NeighborCompactionsQuiet(int level);
 


### PR DESCRIPTION
This branch fixes an oversight in the original timed grooming implementation.  This branch also disables timed grooming until its block cache impact is mitigated.

Details are here:  https://github.com/basho/leveldb/wiki/mv-timed-grooming2
