### PR TITLE
Switch from <cstdatomic> to <atomic>

### DIFF
--- a/build_detect_platform
+++ b/build_detect_platform
@@ -156,11 +156,11 @@ if [ "$CROSS_COMPILE" = "true" ]; then
 else
     # If -std=c++0x works, use <cstdatomic>.  Otherwise use port_posix.h.
     $CXX $CFLAGS -std=c++0x -x c++ - -o /dev/null 2>/dev/null  <<EOF
-      #include <cstdatomic>
+      #include <atomic>
       int main() {}
 EOF
     if [ "$?" = 0 ]; then
-        COMMON_FLAGS="$COMMON_FLAGS -DLEVELDB_PLATFORM_POSIX -DLEVELDB_CSTDATOMIC_PRESENT"
+        COMMON_FLAGS="$COMMON_FLAGS -DLEVELDB_PLATFORM_POSIX -DLEVELDB_ATOMIC_PRESENT"
         PLATFORM_CXXFLAGS="-std=c++0x"
     else
         COMMON_FLAGS="$COMMON_FLAGS -DLEVELDB_PLATFORM_POSIX"

--- a/port/atomic_pointer.h
+++ b/port/atomic_pointer.h
@@ -20,9 +20,9 @@
 #define PORT_ATOMIC_POINTER_H_
 
 #include <stdint.h>
-//#ifdef LEVELDB_CSTDATOMIC_PRESENT
-//#include <cstdatomic>              ... moved below
-//#endif
+#ifdef LEVELDB_ATOMIC_PRESENT
+#include <atomic>
+#endif
 #ifdef OS_WIN
 #include <windows.h>
 #endif
@@ -114,9 +114,8 @@ class AtomicPointer {
   }
 };
 
-// AtomicPointer based on <cstdatomic>
-#elif defined(LEVELDB_CSTDATOMIC_PRESENT)
-#include <cstdatomic>
+// AtomicPointer based on <atomic>
+#elif defined(LEVELDB_ATOMIC_PRESENT)
 
 class AtomicPointer {
  private:


### PR DESCRIPTION
Switch from <cstdatomic> to <atomic>. The former never made it into the
standard and doesn't exist in modern gcc versions at all.  The later contains
everything that leveldb was using from the former.

Backported from Google leveldb 1.18
https://github.com/google/leveldb/commit/803d69203a62faf50f1b77897310a3a1fcae712b
