### PR TITLE
missing lines from hot threads merge causing eleveldb iterator problems [JIRA: RIAK-2640]

### DIFF
--- a/BASHO_RELEASES
+++ b/BASHO_RELEASES
@@ -1,0 +1,5 @@
+github.com tag 2.0.21 - June 16, 2016
+-------------------------------------
+branch mv-iterator-hot-threads:  correct condition where eleveldb MoveTask
+ could hang an iterator. (https://github.com/basho/leveldb/wiki/mv-iterator-hot-threads)
+

--- a/util/hot_threads.cc
+++ b/util/hot_threads.cc
@@ -330,6 +330,11 @@ QueueThread::QueueThreadRoutine()
         {
             // execute the job
             (*submission)();
+            if (submission->resubmit())
+            {
+                submission->recycle();
+                m_Pool.Submit(submission);
+            }
 
             submission->RefDec();
 


### PR DESCRIPTION
Only one of two leveldb hot_threads routine received special eleveldb iterator reuse code during the merge of eleveldb's hot threads and leveldb's hot threads.  This branch pastes the missing 5 lines into the second routine.  

Details here: https://github.com/basho/leveldb/wiki/mv-iterator-hot-threads
