### PR TITLE
Mv expiry iter bug

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -1752,7 +1752,8 @@ Iterator* DBImpl::NewIterator(const ReadOptions& options) {
       &dbname_, env_, user_comparator(), internal_iter,
       (options.snapshot != NULL
        ? reinterpret_cast<const SnapshotImpl*>(options.snapshot)->number_
-       : latest_snapshot));
+       : latest_snapshot),
+      options_.expiry_module.get());
 }
 
 const Snapshot* DBImpl::GetSnapshot() {


### PR DESCRIPTION
DBImpl::NewIterator() was not setting expiry module when creating iterator object.

A detail discussion of this fix is found here:

https://github.com/basho/leveldb/wiki/mv-exiry-iter-bug
