### PR TITLE
Mv mem fences

### DIFF
--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -82,7 +82,9 @@ class DBIter: public Iterator {
     if (kForward==direction_)
     {
       ParsedInternalKey parsed;
-      parsed.type=kTypeValue; parsed.sequence=0; parsed.expiry=0; // clear warnings
+      // this initialization clears a warning.  ParsedInternalKey says
+      //  it is not initializing for performance reasons ... oh well
+      parsed.type=kTypeValue; parsed.sequence=0; parsed.expiry=0;
       ParseInternalKey(iter_->key(), &parsed);
       keymetadata_.m_Type=parsed.type;
       keymetadata_.m_Sequence=parsed.sequence;

--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -82,6 +82,7 @@ class DBIter: public Iterator {
     if (kForward==direction_)
     {
       ParsedInternalKey parsed;
+      parsed.type=kTypeValue; parsed.sequence=0; parsed.expiry=0; // clear warnings
       ParseInternalKey(iter_->key(), &parsed);
       keymetadata_.m_Type=parsed.type;
       keymetadata_.m_Sequence=parsed.sequence;

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1343,7 +1343,7 @@ VersionSet::UpdatePenalty(
         {
             const uint64_t level_bytes = TotalFileSize(v->files_[level]);
 
-            count=static_cast<double>(level_bytes) / gLevelTraits[level].m_MaxBytesForLevel;
+            count=(int)(static_cast<double>(level_bytes) / gLevelTraits[level].m_MaxBytesForLevel);
 
             if (0<count)
             {
@@ -1357,7 +1357,7 @@ VersionSet::UpdatePenalty(
             //  not worse because of this.
             else if (config::kNumOverlapLevels==level)
             {   // light penalty
-                count=static_cast<double>(level_bytes) / gLevelTraits[level].m_DesiredBytesForLevel;
+                count=(int)(static_cast<double>(level_bytes) / gLevelTraits[level].m_DesiredBytesForLevel);
                 value=count; // this approximates the number of compactions needed, no other penalty
                 increment=1;
                 count=0;

--- a/leveldb_os/expiry_os.cc
+++ b/leveldb_os/expiry_os.cc
@@ -215,7 +215,6 @@ bool ExpiryModuleOS::CompactionFinalizeCallback(
         ExpiryTime now, aged;
         const std::vector<FileMetaData*> & files(Ver.GetFileList(Level));
         std::vector<FileMetaData*>::const_iterator it;
-        size_t old_index[config::kNumLevels];
 
         now=GetTimeMinutes();
         aged=now - expiry_minutes*60*port::UINT64_ONE_SECOND;

--- a/tools/perf_dump.cc
+++ b/tools/perf_dump.cc
@@ -23,6 +23,7 @@ main(
 
     running=true;
     error_seen=false;
+    error_counter=0;
 
     csv_header=false;
     diff_mode=false;

--- a/util/flexcache.cc
+++ b/util/flexcache.cc
@@ -45,7 +45,8 @@ FlexCache::FlexCache()
     // initialize total memory available based upon system data
     ret_val=getrlimit(RLIMIT_DATA, &limit);
 
-    if (0==ret_val && RLIM_INFINITY!=limit.rlim_max)
+    //  unsigned long caste to fix warning in smartos1.8, smartos 13.1, solaris10
+    if (0==ret_val && (unsigned long)RLIM_INFINITY!=limit.rlim_max)
     {
         // 2Gig is "small ram", Riak going to be tight
        if (limit.rlim_max < flex::kRlimSizeIsSmall)

--- a/util/hot_threads.cc
+++ b/util/hot_threads.cc
@@ -291,7 +291,6 @@ HotThreadPool::Submit(
     bool OkToQueue)
 {
     bool ret_flag(false);
-    int ret_val;
 
     if (NULL!=item)
     {


### PR DESCRIPTION
This is one of two parallel branches named mv-mem-fences.  The second branch is within the eleveldb repository.  The two branches must be used together.  

The branches address an extremely rare race condition that causes a protective assert() to fire within eleveldb's refobjects.cc.

A detailed description of the bug and fix is found here:

https://github.com/basho/leveldb/wiki/mv-mem-fences
