### PR TITLE
Only switch manifest format if expiry actually used

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -272,7 +272,7 @@ Status DBImpl::NewDB() {
   {
     log::Writer log(file);
     std::string record;
-    new_db.EncodeTo(&record);
+    new_db.EncodeTo(&record, options_.ExpiryActivated());
     s = log.AddRecord(record);
     if (s.ok()) {
       s = file->Close();

--- a/db/dbformat.cc
+++ b/db/dbformat.cc
@@ -230,7 +230,7 @@ KeyRetirement::operator()(
             else
             {
                 expire_flag=false;
-                if (NULL!=options && NULL!=options->expiry_module.get())
+                if (NULL!=options && options->ExpiryActivated())
                     expire_flag=options->expiry_module->KeyRetirementCallback(ikey);
 
                 if ((ikey.type == kTypeDeletion || expire_flag)

--- a/db/memtable.cc
+++ b/db/memtable.cc
@@ -147,7 +147,7 @@ bool MemTable::Get(const LookupKey& key, Value* value, Status* s,
         case kTypeValueExplicitExpiry:
         {
             bool expired=false;
-            if (NULL!=options && NULL!=options->expiry_module.get())
+            if (NULL!=options && options->ExpiryActivated())
                 expired=options->expiry_module->MemTableCallback(internal_key);
             if (expired)
             {

--- a/db/repair.cc
+++ b/db/repair.cc
@@ -455,7 +455,7 @@ class Repairer {
     {
       log::Writer log(file);
       std::string record;
-      edit_.EncodeTo(&record);
+      edit_.EncodeTo(&record);  // manifest format is default for release, options_ often incomplete
       status = log.AddRecord(record);
     }
     if (status.ok()) {

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -313,7 +313,7 @@ static bool SaveValue(void* arg, const Slice& ikey, const Slice& v) {
   } else {
     if (s->ucmp->Compare(parsed_key.user_key, s->user_key) == 0) {
       match=true;
-      if (NULL!=s->options && NULL!=s->options->expiry_module.get())
+      if (NULL!=s->options && s->options->ExpiryActivated())
         expired=s->options->expiry_module->KeyRetirementCallback(parsed_key);
       s->state = (parsed_key.type != kTypeDeletion && !expired) ? kFound : kDeleted;
       if (s->state == kFound) {
@@ -904,7 +904,7 @@ Status VersionSet::LogAndApply(VersionEdit* edit, port::Mutex* mu) {
             // Write new record to MANIFEST log
             if (s.ok()) {
                 std::string record;
-                edit->EncodeTo(&record, true);
+                edit->EncodeTo(&record, options_->ExpiryActivated());
                 s = descriptor_log_->AddRecord(record);
                 if (s.ok()) {
                     s = descriptor_file_->Sync();
@@ -1249,7 +1249,7 @@ VersionSet::Finalize(Version* v)
             }   // if
 
             // finally test for expiry if no compaction candidates
-            if (!compaction_found && NULL!=options_->expiry_module.get())
+            if (!compaction_found && options_->ExpiryActivated())
             {
                 compaction_found=options_->expiry_module->CompactionFinalizeCallback(false,
                                                                                      *v,
@@ -1410,7 +1410,7 @@ Status VersionSet::WriteSnapshot(log::Writer* log) {
   }
 
   std::string record;
-  edit.EncodeTo(&record, true);
+  edit.EncodeTo(&record, options_->ExpiryActivated());
   return log->AddRecord(record);
 }
 

--- a/db/write_batch.cc
+++ b/db/write_batch.cc
@@ -146,7 +146,7 @@ class MemTableInserter : public WriteBatch::Handler {
     ValueType type_use(type);
     ExpiryTime expiry_use(expiry);
 
-    if (NULL!=options_ && NULL!=options_->expiry_module.get())
+    if (NULL!=options_ && options_->ExpiryActivated())
         options_->expiry_module->MemTableInserterCallback(key, value, type_use, expiry_use);
     mem_->Add(sequence_, (ValueType)type_use, key, value, expiry_use);
     sequence_++;

--- a/include/leveldb/expiry.h
+++ b/include/leveldb/expiry.h
@@ -48,6 +48,10 @@ public:
     virtual void Dump(Logger * log) const
     {Log(log,"                        Expiry: (none)");};
 
+    // Quick test to allow manifest logic and such know if
+    //  extra expiry logic should be checked
+    virtual bool ExpiryActivated() const {return(false);};
+
     // db/write_batch.cc MemTableInserter::Put() calls this.
     // returns false on internal error
     virtual bool MemTableInserterCallback(

--- a/include/leveldb/options.h
+++ b/include/leveldb/options.h
@@ -258,6 +258,9 @@ struct Options {
 
   void Dump(Logger * log) const;
 
+  bool ExpiryActivated() const
+        {return(NULL!=expiry_module.get() && expiry_module->ExpiryActivated());};
+
 private:
 
 };

--- a/leveldb_os/expiry_os.h
+++ b/leveldb_os/expiry_os.h
@@ -46,6 +46,10 @@ public:
     // Print expiry options to LOG file
     virtual void Dump(Logger * log) const;
 
+    // Quick test to allow manifest logic and such know if
+    //  extra expiry logic should be checked
+    virtual bool ExpiryActivated() const {return(expiry_enabled);};
+
     // db/write_batch.cc MemTableInserter::Put() calls this.
     // returns false on internal error
     virtual bool MemTableInserterCallback(

--- a/table/table_builder.cc
+++ b/table/table_builder.cc
@@ -145,6 +145,8 @@ void TableBuilder::Add(const Slice& key, const Slice& value) {
       r->sst_counters.Set(eSstCountSequence,ExtractSequenceNumber(key));
 
   // statistics if an expiry key
+  //  Note: not using ExpiryActivated().  Forcing expiry statistics which
+  //  are upgrade / downgrade safe.
   if (NULL!=r->options.expiry_module.get())
   {
       r->options.expiry_module->TableBuilderCallback(key, r->sst_counters);

--- a/util/hot_backup.cc
+++ b/util/hot_backup.cc
@@ -479,7 +479,7 @@ DBImpl::WriteBackupManifest()
     {
         log::Writer log(file);
         std::string record;
-        edit.EncodeTo(&record);
+        edit.EncodeTo(&record, options_.ExpiryActivated());
         status = log.AddRecord(record);
 
         if (status.ok())

--- a/util/options.cc
+++ b/util/options.cc
@@ -89,6 +89,7 @@ Options::Dump(
     Log(log,"    Options.tiered_slow_prefix: %s", tiered_slow_prefix.c_str());
     Log(log,"                        crc32c: %s", crc32c::IsHardwareCRC() ? "hardware" : "software");
     Log(log,"  Options.cache_object_warming: %s", cache_object_warming ? "true" : "false");
+    Log(log,"       Options.ExpiryActivated: %s", ExpiryActivated() ? "true" : "false");
 
     if (NULL!=expiry_module.get())
         expiry_module->Dump(log);


### PR DESCRIPTION
Actively set second param of VersionEdit.EncodeTo() based upon whether or not expiry module is active.  The flag controls whether manifest is traditional format or new Expiry enabled format which is NOT backward compatible.

Implementation created a generic ExpiryActivated() const function in the Options and ExpiryModule classes.  Adjusted code everywhere to use this accessor function instead of explicit tests.
