### PR TITLE
Exclude Riak's "metadata" key from global expiry

### DIFF
--- a/db/dbformat.cc
+++ b/db/dbformat.cc
@@ -59,6 +59,20 @@ std::string ParsedInternalKey::DebugStringHex() const {
   return result;
 }
 
+
+const char * KeyTypeString(ValueType val_type) {
+  const char * ret_ptr;
+  switch(val_type)
+  {
+      case kTypeDeletion: ret_ptr="kTypeDelete"; break;
+      case kTypeValue:    ret_ptr="kTypeValue"; break;
+      case kTypeValueWriteTime: ret_ptr="kTypeValueWriteTime"; break;
+      case kTypeValueExplicitExpiry: ret_ptr="kTypeValueExplicitExpiry"; break;
+      default: ret_ptr="(unknown ValueType)"; break;
+  }   // switch
+  return(ret_ptr);
+}
+
 std::string InternalKey::DebugString() const {
   std::string result;
   ParsedInternalKey parsed;

--- a/db/dbformat.h
+++ b/db/dbformat.h
@@ -132,6 +132,8 @@ inline size_t KeySuffixSize(ValueType val_type) {
   return(ret_val);
 }
 
+const char * KeyTypeString(ValueType val_type);
+
 inline size_t KeySuffixSize(const Slice & internal_key) {
     return(KeySuffixSize(ExtractValueType(internal_key)));
 }

--- a/include/leveldb/options.h
+++ b/include/leveldb/options.h
@@ -371,6 +371,8 @@ struct KeyMetaData
     {};
 };  // struct KeyMetaData
 
+const char * CompileOptionsString();
+
 }  // namespace leveldb
 
 #endif  // STORAGE_LEVELDB_INCLUDE_OPTIONS_H_

--- a/leveldb_os/compile_opt.cc
+++ b/leveldb_os/compile_opt.cc
@@ -1,0 +1,32 @@
+// -------------------------------------------------------------------
+//
+// compile_opt.h
+//
+// Copyright (c) 2016 Basho Technologies, Inc. All Rights Reserved.
+//
+// This file is provided to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file
+// except in compliance with the License.  You may obtain
+// a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+// -------------------------------------------------------------------
+
+#include "leveldb/options.h"
+
+namespace leveldb
+{
+    const char * CompileOptionsString()
+    {
+        return("(open source)");
+    }
+}  // namespace leveldb
+

--- a/tools/sst_scan.cc
+++ b/tools/sst_scan.cc
@@ -1,5 +1,6 @@
 #include <stdlib.h>
 #include <libgen.h>
+#include <arpa/inet.h>
 
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
@@ -21,6 +22,8 @@
 //#include "db/log_reader.h"
 
 void command_help();
+bool PrintSextKey(leveldb::Slice & Cursor, int Limit=1);
+bool PrintSextAtom(leveldb::Slice & Cursor);
 
 int
 main(
@@ -28,7 +31,7 @@ main(
     char ** argv)
 {
     bool error_seen, index_keys, all_keys, block_info, csv_header, counter_info,
-        running, no_csv, summary_only;
+        running, no_csv, summary_only, riak_translations;
     int error_counter;
     char ** cursor;
 
@@ -42,6 +45,7 @@ main(
     all_keys=false;
     no_csv=false;
     summary_only=false;
+    riak_translations=false;
 
     error_counter=0;
 
@@ -62,6 +66,7 @@ main(
                 case 'i':  index_keys=true; break;
                 case 'k':  all_keys=true; break;
                 case 'n':  no_csv=true; break;
+                case 'r':  riak_translations=true; break;
                 case 's':  summary_only=true; break;
                 default:
                     fprintf(stderr, " option \'%c\' is not valid\n", flag);
@@ -231,6 +236,15 @@ main(
 
                                     ParseInternalKey(key, &parsed);
                                     printf("%s block_key %s\n", parsed.DebugStringHex().c_str(), table_name.c_str());
+
+                                    if (riak_translations && '\x10'==*parsed.user_key.data())
+                                    {
+                                        leveldb::Slice cursor_slice;
+                                        cursor_slice=parsed.user_key;
+                                        printf("     ");
+                                        PrintSextKey(cursor_slice);
+                                        printf("\n");
+                                    }   // if
                                 }   // if
                             }   // if
                             else
@@ -330,6 +344,165 @@ command_help()
     fprintf(stderr, "      -k  print all keys\n");
     fprintf(stderr, "      -n  NO csv data (or header)\n");
 }   // command_help
+
+
+/**
+ * Recursive routine to give idea of key contents
+ */
+bool
+PrintSextKey(
+    leveldb::Slice & Cursor,
+    int Limit)
+{
+    int loop;
+    bool good(true);
+
+    for (loop=0; loop<Limit && good; ++loop)
+    {
+        if (0<loop)
+            printf(",");
+
+        switch(*Cursor.data())
+        {
+            case(16):   // tuple
+            {
+                uint32_t count;
+
+                Cursor.remove_prefix(1);
+                count=ntohl(*(uint32_t*)Cursor.data());
+                Cursor.remove_prefix(4);
+
+                printf("{");
+                good=PrintSextKey(Cursor, count);
+                printf("}");
+                break;
+            }   // tuple
+
+            case(12):   // atom
+            {
+                Cursor.remove_prefix(1);
+                good=PrintSextAtom(Cursor);
+                break;
+            }   // atom
+
+            case(18):   // binary
+            {
+                Cursor.remove_prefix(1);
+                printf("<<");
+                good=PrintSextAtom(Cursor);
+                printf(">>");
+                break;
+            }   // atom
+        }   // switch
+    }   // for
+
+    return(good);
+
+}   // PrintSextKey
+
+
+bool
+PrintSextAtom(
+    leveldb::Slice & Cursor)
+{
+    bool good(true);
+    uint8_t mask(0x80);
+    char output;
+
+    while(good && (uint8_t)*Cursor.data() & mask)
+    {
+        switch(mask)
+        {
+            case(0x80):
+            {
+                output=(*Cursor.data() & 0x7f) << 1;
+                Cursor.remove_prefix(1);
+                output+=(*Cursor.data() & 0x80) >> 7;
+                printf("%c",output);
+                mask=0x40;
+                break;
+            }
+
+            case(0x40):
+            {
+                output=(*Cursor.data() & 0x3f) << 2;
+                Cursor.remove_prefix(1);
+                output+=(*Cursor.data() & 0xc0) >> 6;
+                printf("%c",output);
+                mask=0x20;
+                break;
+            }
+
+            case(0x20):
+            {
+                output=(*Cursor.data() & 0x1f) << 3;
+                Cursor.remove_prefix(1);
+                output+=(*Cursor.data() & 0xe0) >> 5;
+                printf("%c",output);
+                mask=0x10;
+                break;
+            }
+
+            case(0x10):
+            {
+                output=(*Cursor.data() & 0x0f) << 4;
+                Cursor.remove_prefix(1);
+                output+=(*Cursor.data() & 0xf0) >> 4;
+                printf("%c",output);
+                mask=0x08;
+                break;
+            }
+
+            case(0x08):
+            {
+                output=(*Cursor.data() & 0x07) << 5;
+                Cursor.remove_prefix(1);
+                output+=(*Cursor.data() & 0xf8) >> 3;
+                printf("%c",output);
+                mask=0x04;
+                break;
+            }
+
+            case(0x04):
+            {
+                output=(*Cursor.data() & 0x03) << 6;
+                Cursor.remove_prefix(1);
+                output+=(*Cursor.data() & 0xfc) >> 2;
+                printf("%c",output);
+                mask=0x02;
+                break;
+            }
+
+            case(0x02):
+            {
+                output=(*Cursor.data() & 0x01) << 7;
+                Cursor.remove_prefix(1);
+                output+=(*Cursor.data() & 0xfe) >> 1;
+                printf("%c",output);
+                mask=0x01;
+                break;
+            }
+
+            case(0x01):
+            {
+                Cursor.remove_prefix(1);
+                output=*Cursor.data();
+                Cursor.remove_prefix(1);
+                printf("%c",output);
+                mask=0x80;
+                break;
+            }
+        }   // switch
+
+    }   // while
+
+    Cursor.remove_prefix(2);
+
+    return(good);
+
+}   // PrintSextAtom
+
+
 
 namespace leveldb {
 

--- a/tools/sst_scan.cc
+++ b/tools/sst_scan.cc
@@ -24,6 +24,7 @@
 void command_help();
 bool PrintSextKey(leveldb::Slice & Cursor, int Limit=1);
 bool PrintSextAtom(leveldb::Slice & Cursor);
+void PrintInternalKeyInfo(leveldb::ParsedInternalKey & ParsedKey);
 
 int
 main(
@@ -244,6 +245,9 @@ main(
                                         printf("     ");
                                         PrintSextKey(cursor_slice);
                                         printf("\n");
+                                        printf("     ");
+                                        PrintInternalKeyInfo(parsed);
+                                        printf("\n");
                                     }   // if
                                 }   // if
                             }   // if
@@ -411,6 +415,7 @@ PrintSextAtom(
 
     while(good && (uint8_t)*Cursor.data() & mask)
     {
+        // this could be done easier with variables instead of fixed constants
         switch(mask)
         {
             case(0x80):
@@ -503,6 +508,16 @@ PrintSextAtom(
 }   // PrintSextAtom
 
 
+void
+PrintInternalKeyInfo(
+    leveldb::ParsedInternalKey & ParsedKey)
+{
+    printf("%s, seq: %llu", leveldb::KeyTypeString(ParsedKey.type), ParsedKey.sequence);
+
+    if (leveldb::IsExpiryKey(ParsedKey.type))
+        printf(", expiry: %llu", ParsedKey.expiry);
+
+}   // PrintInternalKeyInfo
 
 namespace leveldb {
 

--- a/tools/sst_scan.cc
+++ b/tools/sst_scan.cc
@@ -512,10 +512,10 @@ void
 PrintInternalKeyInfo(
     leveldb::ParsedInternalKey & ParsedKey)
 {
-    printf("%s, seq: %llu", leveldb::KeyTypeString(ParsedKey.type), ParsedKey.sequence);
+    printf("%s, seq: %" PRIu64, leveldb::KeyTypeString(ParsedKey.type), ParsedKey.sequence);
 
     if (leveldb::IsExpiryKey(ParsedKey.type))
-        printf(", expiry: %llu", ParsedKey.expiry);
+        printf(", expiry: %" PRIu64, ParsedKey.expiry);
 
 }   // PrintInternalKeyInfo
 

--- a/util/options.cc
+++ b/util/options.cc
@@ -60,7 +60,7 @@ void
 Options::Dump(
     Logger * log) const
 {
-    Log(log,"                       Version: %s", STR(LEVELDB_VSN));
+    Log(log,"                       Version: %s %s", STR(LEVELDB_VSN), CompileOptionsString());
     Log(log,"            Options.comparator: %s", comparator->Name());
     Log(log,"     Options.create_if_missing: %d", create_if_missing);
     Log(log,"       Options.error_if_exists: %d", error_if_exists);


### PR DESCRIPTION
Riak creates a special metadata key within its databases (vnodes).  This key needs to be explicitly excluded from global expiry.

Detail documentation is here:
    https://github.com/basho/leveldb/wiki/mv-no-md-expiry
