### PR TITLE
Correct two problems with expiry "unlimited"

### DIFF
--- a/util/expiry_os.cc
+++ b/util/expiry_os.cc
@@ -67,11 +67,11 @@ ExpiryModuleOS::MemTableInserterCallback(
 {
     bool good(true);
 
-    // only update the expiry time if explicit type
-    //  without expiry, OR ExpiryMinutes set and not internal key
+    // only update the expiry time if:
+    //   a. expiry write time set without time
+    //   b. expiry enabled and normal key
     if ((kTypeValueWriteTime==ValType && 0==Expiry)
         || (kTypeValue==ValType
-            && 0!=expiry_minutes
             && expiry_enabled
             && (Key.size()<lRiakMetaDataKeyLen
                 || 0!=memcmp(lRiakMetaDataKey,Key.data(),lRiakMetaDataKeyLen))))
@@ -240,7 +240,9 @@ bool ExpiryModuleOS::CompactionFinalizeCallback(
 {
     bool ret_flag(false);
 
-    if (expiry_enabled && whole_file_expiry)
+    // expiry_minutes of zero disables whole_file_expiry
+    if (expiry_enabled && whole_file_expiry
+        && 0!=expiry_minutes)
     {
         bool expired_file(false);
         ExpiryTime now, aged;

--- a/util/expiry_os_test.cc
+++ b/util/expiry_os_test.cc
@@ -129,6 +129,7 @@ TEST(ExpiryTester, MemTableInserterCallback)
     // plain value, expiry disabled
     type=kTypeValue;
     expiry=0;
+    module.expiry_enabled=false;
     module.expiry_minutes=0;
     before=port::TimeUint64();
     SetTimeMinutes(before);
@@ -137,6 +138,19 @@ TEST(ExpiryTester, MemTableInserterCallback)
     ASSERT_EQ(flag, true);
     ASSERT_EQ(type, kTypeValue);
     ASSERT_EQ(expiry, 0);
+
+    // plain value, expiry enabled, minutes = 0
+    type=kTypeValue;
+    expiry=0;
+    module.expiry_enabled=true;
+    module.expiry_minutes=0;
+    before=port::TimeUint64();
+    SetTimeMinutes(before);
+    flag=module.MemTableInserterCallback(key, value, type, expiry);
+    after=port::TimeUint64();
+    ASSERT_EQ(flag, true);
+    ASSERT_EQ(type, kTypeValueWriteTime);
+    ASSERT_TRUE(before <= expiry && expiry <=after && 0!=expiry);
 
     // write time value, needs expiry
     type=kTypeValueWriteTime;
@@ -364,9 +378,9 @@ TEST(ExpiryTester, CompactionFinalizeCallback1)
     module.expiry_minutes=0;
     ver.SetFileList(level, files);
     flag=module.CompactionFinalizeCallback(true, ver, level, NULL);
-    ASSERT_EQ(flag, true);
+    ASSERT_EQ(flag, false);
     flag=module.CompactionFinalizeCallback(false, ver, level, NULL);
-    ASSERT_EQ(flag, true);
+    ASSERT_EQ(flag, false);
 
     // remove explicit
     files.pop_back();


### PR DESCRIPTION
#Two issues with current implementation of "unlimited" expiry:

- the goal of the unlimited option (expiry_minutes=0) was to have leveldb mark the write time on incoming records, but never use the time for expiry.  expiry_minutes of zero would NOT add the write time in MemTableInserterCallback(), violating the desire result.  Corrected.

- expiry_minutes==0 was not properly tested for whole file delete decisions.  It was possible for expiry_minutes==0 to cause files to be deleted just after being created.  Corrected.