### PR TITLE
Address case where non-tiered storage hot backup will not delete backup.4 directory.

### DIFF
--- a/db/filename.cc
+++ b/db/filename.cc
@@ -282,7 +282,7 @@ MakeTieredDbname(
     Options & options)             // input/output ... writable Options, tiered values changed
 {
     // case for "", used with internal calls to DestroyDB
-    if (0==dbname.length() && 0!=options.tiered_fast_prefix.length())
+    if (0==dbname.size() && 0!=options.tiered_fast_prefix.size())
     {
         // do NOTHING ... options already initialized
     }   // if

--- a/db/filename.cc
+++ b/db/filename.cc
@@ -281,7 +281,12 @@ MakeTieredDbname(
     const std::string & dbname,    // input ... original dbname from DBImpl constructor
     Options & options)             // input/output ... writable Options, tiered values changed
 {
-    if (0<(int)options.tiered_slow_level && (int)options.tiered_slow_level<config::kNumLevels
+    // case for "", used with internal calls to DestroyDB
+    if (0==dbname.length() && 0!=options.tiered_fast_prefix.length())
+    {
+        // do NOTHING ... options already initialized
+    }   // if
+    else if (0<(int)options.tiered_slow_level && (int)options.tiered_slow_level<config::kNumLevels
         && 0!=options.tiered_fast_prefix.size() && 0!=options.tiered_slow_prefix.size())
     {
         options.tiered_fast_prefix.append("/");
@@ -289,7 +294,7 @@ MakeTieredDbname(
 
         options.tiered_slow_prefix.append("/");
         options.tiered_slow_prefix.append(dbname);
-    }
+    }   // else if
     else
     {
         options.tiered_slow_level=0;

--- a/db/filename_test.cc
+++ b/db/filename_test.cc
@@ -178,6 +178,12 @@ TEST(FileNameTest, Construction) {
   ASSERT_EQ("//mnt/fast/riak/data/leveldb", options.tiered_fast_prefix);
   ASSERT_EQ("//mnt/slow/riak/data/leveldb", options.tiered_slow_prefix);
 
+  // special case with no dbname given, should have no changes
+  fname=MakeTieredDbname("", options);
+  ASSERT_EQ("//mnt/fast/riak/data/leveldb", fname);
+  ASSERT_EQ("//mnt/fast/riak/data/leveldb", options.tiered_fast_prefix);
+  ASSERT_EQ("//mnt/slow/riak/data/leveldb", options.tiered_slow_prefix);
+
 }
 
 }  // namespace leveldb


### PR DESCRIPTION
The hot backup code was extensively tested with the more difficult configuration of tiered storage. Therefore a bug in the simpler non-tiered storage was missed. The routine MakeTieredDbname() in db/filename.cc was originally designed to populate fast and slow tier names of the Options structure given a user's database path.

Hot backup is an internal user. It does not know how tiered storage was or was not constructed from components. Therefore, hot backup calls DestroyDB() (db/db_impl.cc) without a database name but with a full populated Options. This works just fine for tiered storage. It failed with non-tiered because MakeTieredDbname() returned a zero length string ... the string was therefore useless for deleting the backup.4 directory.

The PR adds a third case to MakeTieredDbname() and creates a unit test for the case within db/filename_test.cc