### PR TITLE
Option to disable leveldb's recovery log

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -224,6 +224,10 @@ DBImpl::DBImpl(const Options& options, const std::string& dbname)
 DBImpl::~DBImpl() {
   DBList()->ReleaseDB(this, options_.is_internal_db);
 
+  // maybe push memory buffer(s) to disk if recovery log disabled
+  if (options_.disable_recovery_log)
+      CompactMemTableSynchronous();
+
   // Wait for background work to finish
   mutex_.Lock();
   shutting_down_.Release_Store(this);  // Any non-NULL value is ok
@@ -1830,10 +1834,13 @@ Status DBImpl::Write(const WriteOptions& options, WriteBatch* my_batch) {
     // into mem_.
     {
       mutex_.Unlock();
-      status = log_->AddRecord(WriteBatchInternal::Contents(updates));
-      if (status.ok() && options.sync) {
-        status = logfile_->Sync();
-      }
+      if (!options_.disable_recovery_log)
+      {
+        status = log_->AddRecord(WriteBatchInternal::Contents(updates));
+        if (status.ok() && options.sync) {
+          status = logfile_->Sync();
+        } // if
+      } // if
       if (status.ok()) {
         status = WriteBatchInternal::InsertInto(updates, mem_, &options_);
       }
@@ -2017,7 +2024,8 @@ Status DBImpl::MakeRoomForWrite(bool force) {
       Log(options_.info_log, "waiting 2...\n");
       gPerfCounters->Inc(ePerfWriteWaitImm);
       MaybeScheduleCompaction();
-      if (!shutting_down_.Acquire_Load())
+      while (imm_ != NULL && bg_error_.ok()
+             && !shutting_down_.Acquire_Load())
           bg_cv_.Wait();
       Log(options_.info_log, "running 2...\n");
     } else if (versions_->NumLevelFiles(0) >= config::kL0_StopWritesTrigger) {
@@ -2070,18 +2078,28 @@ Status DBImpl::NewRecoveryLog(
     Status s;
     WritableFile * lfile(NULL);
 
-    s = env_->NewWriteOnlyFile(LogFileName(dbname_, NewLogNumber), &lfile,
-                               options_.env->RecoveryMmapSize(&options_));
-    if (s.ok())
+    if (!options_.disable_recovery_log)
     {
-        // close any existing
-        delete log_;
-        delete logfile_;
+        s = env_->NewWriteOnlyFile(LogFileName(dbname_, NewLogNumber), &lfile,
+                               options_.env->RecoveryMmapSize(&options_));
+        if (s.ok())
+        {
+            // close any existing
+            delete log_;
+            delete logfile_;
 
-        logfile_ = lfile;
-        logfile_number_ = NewLogNumber;
-        log_ = new log::Writer(lfile);
+            logfile_ = lfile;
+            logfile_number_ = NewLogNumber;
+            log_ = new log::Writer(lfile);
+        }   // if
     }   // if
+
+    // keep asserts valid
+    else
+    {
+        logfile_number_ = NewLogNumber;
+    }   // else
+
 
     return(s);
 

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -153,6 +153,7 @@ class DBTest {
     kDefault,
     kFilter,
     kUncompressed,
+    kDisableRecovery,
     kEnd
   };
   int option_config_;
@@ -201,6 +202,9 @@ class DBTest {
         break;
       case kUncompressed:
         options.compression = kNoCompression;
+        break;
+      case kDisableRecovery:
+        options.disable_recovery_log = true;
         break;
       default:
         break;
@@ -1073,7 +1077,10 @@ TEST(DBTest, ApproximateSizes) {
       }
 
       ASSERT_EQ(NumTableFilesAtLevel(0), 0);
-      ASSERT_GT(NumTableFilesAtLevel(1), 0);
+      if (!CurrentOptions().disable_recovery_log)
+          ASSERT_GT(NumTableFilesAtLevel(1), 0);
+      else
+          ASSERT_GT(NumTableFilesAtLevel(3), 0); // code path uses move
     }
   } while (ChangeOptions());
 }

--- a/include/leveldb/options.h
+++ b/include/leveldb/options.h
@@ -249,6 +249,12 @@ struct Options {
   // upon restart.
   bool cache_object_warming;
 
+  // Riak specific option to disable writing of recovery log
+  //  during DB::Write() / Put() calls.  This speeds performance
+  //  but can lead to loss of tens of megabytes of data if
+  //  system crashes.  Used in Riak for temporary tables only.
+  bool disable_recovery_log;
+
   // Riak specific object that defines expiry policy for data
   // written to leveldb.
   ExpiryPtr_t expiry_module;

--- a/util/options.cc
+++ b/util/options.cc
@@ -50,7 +50,8 @@ Options::Options()
       delete_threshold(1000),
       fadvise_willneed(false),
       tiered_slow_level(0),
-      cache_object_warming(true)
+      cache_object_warming(true),
+      disable_recovery_log(false)
 {
 
 }
@@ -89,6 +90,7 @@ Options::Dump(
     Log(log,"    Options.tiered_slow_prefix: %s", tiered_slow_prefix.c_str());
     Log(log,"                        crc32c: %s", crc32c::IsHardwareCRC() ? "hardware" : "software");
     Log(log,"  Options.cache_object_warming: %s", cache_object_warming ? "true" : "false");
+    Log(log,"  Options.disable_recovery_log: %s", disable_recovery_log ? "true" : "false");
     Log(log,"       Options.ExpiryActivated: %s", ExpiryActivated() ? "true" : "false");
 
     if (NULL!=expiry_module.get())


### PR DESCRIPTION
THIS IS AN EXTREMELY DANGEROUS FEATURE.  IT CAN EASILY LEAD TO DATA LOSS.

This feature is intended for use with certain internal, non-durable cache scenarios.  The data placed into a leveldb database with this option set is vulnerable to loss if system dies or program aborts/segfaults.

Branch discussion is here:  https://github.com/basho/leveldb/wiki/mv-disable-recovery-log
